### PR TITLE
change block count param to hex

### DIFF
--- a/integration/mainnet/eth_feeHistory/test_01.json
+++ b/integration/mainnet/eth_feeHistory/test_01.json
@@ -8,7 +8,7 @@
             "jsonrpc": "2.0",
             "method": "eth_feeHistory",
             "params": [
-                1,
+                "0x1",
                 "0x867A80",
                 [25, 75]
             ],

--- a/integration/mainnet/eth_feeHistory/test_02.json
+++ b/integration/mainnet/eth_feeHistory/test_02.json
@@ -8,7 +8,7 @@
             "jsonrpc": "2.0",
             "method": "eth_feeHistory",
             "params": [
-                2,
+               "0x2",
                 "0x737A80",
                 [10, 50, 90]
             ],

--- a/integration/mainnet/eth_feeHistory/test_03.json
+++ b/integration/mainnet/eth_feeHistory/test_03.json
@@ -8,7 +8,7 @@
             "jsonrpc": "2.0",
             "method": "eth_feeHistory",
             "params": [
-                5,
+               "0x5",
                 "0x685A80",
                 [25, 50, 75]
             ],

--- a/integration/mainnet/eth_feeHistory/test_04.json
+++ b/integration/mainnet/eth_feeHistory/test_04.json
@@ -8,7 +8,7 @@
             "jsonrpc": "2.0",
             "method": "eth_feeHistory",
             "params": [
-                2,
+               "0x2",
                 "0x125A80",
                 [0, 50, 100]
             ],

--- a/integration/mainnet/eth_feeHistory/test_05.json
+++ b/integration/mainnet/eth_feeHistory/test_05.json
@@ -8,7 +8,7 @@
             "jsonrpc": "2.0",
             "method": "eth_feeHistory",
             "params": [
-                2,
+               "0x2",
                 "0xF42400",
                 [100]
             ],

--- a/integration/mainnet/eth_feeHistory/test_06.json
+++ b/integration/mainnet/eth_feeHistory/test_06.json
@@ -8,7 +8,7 @@
             "jsonrpc": "2.0",
             "method": "eth_feeHistory",
             "params": [
-                2,
+               "0x2",
                 "0x9",
                 [5,95]
             ],

--- a/integration/mainnet/eth_feeHistory/test_07.json
+++ b/integration/mainnet/eth_feeHistory/test_07.json
@@ -8,7 +8,7 @@
             "jsonrpc": "2.0",
             "method": "eth_feeHistory",
             "params": [
-                2,
+                "0x2",
                 "latest",
                 [1,5,95,100]
             ],

--- a/integration/mainnet/eth_feeHistory/test_08.json
+++ b/integration/mainnet/eth_feeHistory/test_08.json
@@ -8,7 +8,7 @@
             "jsonrpc": "2.0",
             "method": "eth_feeHistory",
             "params": [
-                10,
+               "0xa",
                 "0xF42400",
                 [50]
             ],


### PR DESCRIPTION
The [specification](https://ethereum.github.io/execution-apis/api-documentation/) defines the `block count` parameter as hex-encoded. 

Both Erigon and Silkworm support hex and decimal (for backwards compatibility). But we should update tests to the latest spec.