### PR TITLE
Add support for HTTPS

### DIFF
--- a/integration/run_tests.py
+++ b/integration/run_tests.py
@@ -388,7 +388,7 @@ class Config:
                         sys.exit(1)
                     tokenize_list = optarg.split(",")
                     for test in tokenize_list:
-                        if test not in ['websocket', 'http', 'http_comp', 'websocket_comp']:
+                        if test not in ['websocket', 'http', 'http_comp', 'https', 'websocket_comp']:
                             print("Error invalid connection type: ", test)
                             print("Error in options: -T/--transport_type http,http_comp,https,websocket,websocket_comp")
                             usage(argv)

--- a/integration/run_tests.py
+++ b/integration/run_tests.py
@@ -98,7 +98,7 @@ def usage(argv):
     print("-s,--start-from-test: <test_number>: run tests starting from input")
     print("-t,--run-single-test: <test_number>: run single test")
     print("-d,--compare-erigon-rpcdaemon: send requests also to the reference daemon e.g.: Erigon RpcDaemon")
-    print("-T,--transport_type: <http,http_comp,websocket,websocket_comp>")
+    print("-T,--transport_type: <http,http_comp,https,websocket,websocket_comp>")
     print("-k,--jwt: authentication token file")
     print("-a,--api-list-with: <apis>: run all tests of the specified API that contains string (e.g.: eth_,debug_)")
     print("-A,--api-list: <apis>: run all tests of the specified API that match full name (e.g.: eth_call,eth_getLogs)")
@@ -383,14 +383,14 @@ class Config:
                     self.force_dump_jsons = 1
                 elif option in ("-T", "--transport_type"):
                     if optarg == "":
-                        print("Error in options: -T/--transport_type http,http_comp,websocket,websocket_comp")
+                        print("Error in options: -T/--transport_type http,http_comp,https,websocket,websocket_comp")
                         usage(argv)
                         sys.exit(1)
                     tokenize_list = optarg.split(",")
                     for test in tokenize_list:
                         if test not in ['websocket', 'http', 'http_comp', 'websocket_comp']:
                             print("Error invalid connection type: ", test)
-                            print("Error in options: -T/--transport_type http,http_comp,websocket,websocket_comp")
+                            print("Error in options: -T/--transport_type http,http_comp,https,websocket,websocket_comp")
                             usage(argv)
                             sys.exit(1)
                     self.transport_type = optarg
@@ -487,7 +487,7 @@ def dump_jsons(dump_json, silk_file, exp_rsp_file, output_dir, response, expecte
 
 def execute_request(transport_type: str, jwt_auth, encoded, request_dumps, target: str, verbose_level: int):
     """ execute request on server identified by target """
-    if transport_type in ("http", 'http_comp'):
+    if transport_type in ("http", 'http_comp', 'https'):
         http_headers = {'content-type': 'application/json'}
         if transport_type != 'http_comp':
             http_headers['Accept-Encoding' ] =  'Identity'
@@ -495,7 +495,7 @@ def execute_request(transport_type: str, jwt_auth, encoded, request_dumps, targe
         if jwt_auth:
             http_headers['Authorization' ] =  jwt_auth
 
-        target_url = "http://" + target
+        target_url = ("https://" if transport_type == "https" else "http://") + target
         try:
             rsp = requests.post(target_url, data=request_dumps, headers=http_headers)
             if rsp.status_code != 200:


### PR DESCRIPTION
Sometimes (or often?) rpcdaemon runs behind a firewall that requires an https connection.
This PR add a simple support for HTTPS. I tested it with a real system.