### PR TITLE
add error field on eth_syncing response

### DIFF
--- a/integration/mainnet/eth_syncing/test_01.json
+++ b/integration/mainnet/eth_syncing/test_01.json
@@ -13,7 +13,8 @@
         "response":{
             "jsonrpc":"2.0",
             "id":1,
-            "result":null
+            "result":null,
+            "error": null
         }
     }
 ]


### PR DESCRIPTION
Erigon has just started filling an error field in the eth_syncing response when rpcdaemon runs without a remote Erigon