### PR TITLE
integration: remove totalDifficulty from eth_getBlockByNumber

### DIFF
--- a/integration/mainnet/eth_getBlockByNumber/test_12.json
+++ b/integration/mainnet/eth_getBlockByNumber/test_12.json
@@ -27,7 +27,6 @@
           "parentHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
           "receiptsRoot": "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
           "sha3Uncles": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
-          "totalDifficulty": "0x400000000",
           "size": "0x21c",
           "stateRoot": "0xd7f8974fb5ac78d9ac099b9ad5018bedc2ce0a72dad1827a1709da30580f0544",
           "timestamp": "0x0",


### PR DESCRIPTION
Erigon recently removed the totalDifficulty field from eth_getBlockByNumber. This PR adjusts the test accordingly