### PR TITLE
integration/mainnet: remove aura fields

### DIFF
--- a/integration/mainnet/erigon_getHeaderByHash/test_01.json
+++ b/integration/mainnet/erigon_getHeaderByHash/test_01.json
@@ -10,8 +10,6 @@
             "jsonrpc":"2.0",
             "id":1,
             "result": {
-           "AuRaSeal": null,
-           "AuRaStep": 0,
            "Verkle": false,
            "VerkleKeyVals": null,
            "VerkleProof": null,

--- a/integration/mainnet/erigon_getHeaderByHash/test_02.json
+++ b/integration/mainnet/erigon_getHeaderByHash/test_02.json
@@ -10,8 +10,6 @@
             "jsonrpc":"2.0",
             "id":1,
             "result": {
-               "AuRaSeal": null,
-               "AuRaStep": 0,
                "Verkle": false,
                "VerkleKeyVals": null,
                "VerkleProof": null,

--- a/integration/mainnet/erigon_getHeaderByHash/test_03.json
+++ b/integration/mainnet/erigon_getHeaderByHash/test_03.json
@@ -10,8 +10,6 @@
             "jsonrpc":"2.0",
             "id":1,
             "result": {
-             "AuRaSeal": null,
-              "AuRaStep": 0,
               "Verkle": false,
               "VerkleKeyVals": null,
               "VerkleProof": null,

--- a/integration/mainnet/erigon_getHeaderByHash/test_04.json
+++ b/integration/mainnet/erigon_getHeaderByHash/test_04.json
@@ -10,8 +10,6 @@
             "jsonrpc":"2.0",
             "id":1,
             "result": {
-                "AuRaSeal": null,
-                "AuRaStep": 0,
                 "Verkle": false,
                 "VerkleKeyVals": null,
                 "VerkleProof": null,

--- a/integration/mainnet/erigon_getHeaderByHash/test_06.json
+++ b/integration/mainnet/erigon_getHeaderByHash/test_06.json
@@ -14,8 +14,6 @@
             "jsonrpc":"2.0",
             "id":1,
             "result": {
-              "AuRaSeal": null,
-              "AuRaStep": 0,
               "Verkle": false,
               "VerkleKeyVals": null,
               "VerkleProof": null,

--- a/integration/mainnet/erigon_getHeaderByNumber/test_01.json
+++ b/integration/mainnet/erigon_getHeaderByNumber/test_01.json
@@ -10,8 +10,6 @@
             "jsonrpc":"2.0",
             "id":1,
             "result": {
-             "AuRaSeal": null,
-              "AuRaStep": 0,
               "Verkle": false,
               "VerkleKeyVals": null,
               "VerkleProof": null,

--- a/integration/mainnet/erigon_getHeaderByNumber/test_02.json
+++ b/integration/mainnet/erigon_getHeaderByNumber/test_02.json
@@ -10,8 +10,6 @@
             "jsonrpc":"2.0",
             "id":1,
             "result": {
-                "AuRaSeal": null,
-                 "AuRaStep": 0,
                  "Verkle": false,
                  "VerkleKeyVals": null,
                  "VerkleProof": null,

--- a/integration/mainnet/erigon_getHeaderByNumber/test_03.json
+++ b/integration/mainnet/erigon_getHeaderByNumber/test_03.json
@@ -10,8 +10,6 @@
             "jsonrpc":"2.0",
             "id":1,
             "result": {
-                 "AuRaSeal": null,
-                 "AuRaStep": 0,
                  "Verkle": false,
                  "VerkleKeyVals": null,
                  "VerkleProof": null,

--- a/integration/mainnet/erigon_getHeaderByNumber/test_04.json
+++ b/integration/mainnet/erigon_getHeaderByNumber/test_04.json
@@ -10,8 +10,6 @@
             "jsonrpc":"2.0",
             "id":1,
             "result": {
-              "AuRaSeal": null,
-               "AuRaStep": 0,
                "Verkle": false,
                "VerkleKeyVals": null,
                "VerkleProof": null,

--- a/integration/mainnet/erigon_getHeaderByNumber/test_05.json
+++ b/integration/mainnet/erigon_getHeaderByNumber/test_05.json
@@ -10,8 +10,6 @@
             "jsonrpc":"2.0",
             "id":1,
             "result": {
-             "AuRaSeal": null,
-              "AuRaStep": 0,
               "Verkle": false,
               "VerkleKeyVals": null,
               "VerkleProof": null,

--- a/integration/mainnet/erigon_getHeaderByNumber/test_06.json
+++ b/integration/mainnet/erigon_getHeaderByNumber/test_06.json
@@ -10,8 +10,6 @@
             "jsonrpc":"2.0",
             "id":1,
             "result": {
-               "AuRaSeal": null,
-               "AuRaStep": 0,
                "Verkle": false,
                "VerkleKeyVals": null,
                "VerkleProof": null,

--- a/integration/mainnet/erigon_getHeaderByNumber/test_07.json
+++ b/integration/mainnet/erigon_getHeaderByNumber/test_07.json
@@ -10,8 +10,6 @@
             "jsonrpc":"2.0",
             "id":1,
             "result": {
-                "AuRaSeal": null,
-                "AuRaStep": 0,
                 "Verkle": false,
                 "VerkleKeyVals": null,
                 "VerkleProof": null,

--- a/integration/mainnet/erigon_getHeaderByNumber/test_08.json
+++ b/integration/mainnet/erigon_getHeaderByNumber/test_08.json
@@ -10,8 +10,6 @@
             "jsonrpc":"2.0",
             "id":1,
   "result": {
-    "AuRaSeal": null,
-    "AuRaStep": 0,
     "Verkle": false,
     "VerkleKeyVals": null,
     "VerkleProof": null,


### PR DESCRIPTION
Aura fields have recently been removed from Erigon Mainnet results.