### PR TITLE
integration: ensure "bor logs" traces can be used in rpc queries

### DIFF
--- a/integration/polygon-pos/eth_getLogs/test_01.json
+++ b/integration/polygon-pos/eth_getLogs/test_01.json
@@ -1,5 +1,9 @@
 [
   {
+    "test": {
+      "reference": "https://polygonscan.com/tx/0xc6bb4df4982ba2a43088e24e787e3e82c391f34162929d370e695cd5830370c2",
+      "description": "\"bor logs\" topics and log addressed are reported back -- indicates if logaddr/logtopics are indexed properly on system txs."
+    },
     "request": {
       "id": 1,
       "jsonrpc": "2.0",

--- a/integration/polygon-pos/eth_getTransactionByHash/test_01.json
+++ b/integration/polygon-pos/eth_getTransactionByHash/test_01.json
@@ -1,9 +1,5 @@
 [
   {
-    "test": {
-      "reference": "https://polygonscan.com/tx/0xe4733eb7834d1e62a2ff484065f1fd07bbb8905c41c1ed963fa139a25cd683dd",
-      "description": "\"bor logs\" topics and log addressed are reported back -- indicates if logaddr/logtopics are indexed properly on system txs."
-    },
     "request": {
       "id": 1,
       "jsonrpc": "2.0",


### PR DESCRIPTION
- generating bor / amoy files currently (3.1)
- needs update to test runner to finish
- can hold this PR till the update is done


issue: https://github.com/erigontech/erigon/issues/16381