### PR TITLE
integration tool: clear result after verify sync is done

### DIFF
--- a/cmd/integration/main.go
+++ b/cmd/integration/main.go
@@ -186,10 +186,6 @@ func parseFlags(cfg *config.Config) error {
 
 	cfg.UpdateDirs()
 
-	if err := cfg.CleanOutputDir(); err != nil {
-		return err
-	}
-
 	return nil
 }
 
@@ -315,7 +311,7 @@ func runMain() int {
 	exitCode, err := runner.Run(ctx, cancelCtx, cfg)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
-		return -1
+		return 2
 	}
 	return exitCode
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -286,7 +286,7 @@ func (c *Config) CleanOutputDir() error {
 
 // ResultsAbsDir returns the absolute path to the results directory.
 func (c *Config) ResultsAbsDir() (string, error) {
-	return filepath.Abs(c.ResultsDir)
+	return filepath.Abs(c.OutputDir)
 }
 
 // GetJWTSecret reads a JWT secret from a file.

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -52,6 +52,10 @@ func Run(ctx context.Context, cancelCtx context.CancelFunc, cfg *config.Config) 
 		}
 	}
 
+	if err := cfg.CleanOutputDir(); err != nil {
+		return -1, err
+	}
+
 	resultsAbsDir, err := cfg.ResultsAbsDir()
 	if err != nil {
 		return -1, err


### PR DESCRIPTION

This PR makes following fixes on integration tool:
1) in case of infra problem return 2 (o -> ok; 1: some tests failed)
2) Correct print where  result dir is located
3) Clear output dir when verify sync is completed