### PR TITLE
eth_sendRawTransaction: expect -32602 for malformed-RLP decode failures

### DIFF
--- a/integration/arb-sepolia/eth_sendRawTransaction/test_01.json
+++ b/integration/arb-sepolia/eth_sendRawTransaction/test_01.json
@@ -12,7 +12,7 @@
       "jsonrpc": "2.0",
       "id": 1,
       "error": {
-        "code": -32000,
+        "code": -32602,
         "message": "rlp: value size exceeds available input length"
       }
     },

--- a/integration/mainnet/eth_sendRawTransaction/test_01.json
+++ b/integration/mainnet/eth_sendRawTransaction/test_01.json
@@ -12,7 +12,7 @@
             "id":1,
             "jsonrpc":"2.0",
             "error":{
-                "code":-32000,
+                "code":-32602,
                 "message":"rlp: value size exceeds available input length"
             }
 

--- a/integration/mainnet/eth_sendRawTransaction/test_02.json
+++ b/integration/mainnet/eth_sendRawTransaction/test_02.json
@@ -12,7 +12,7 @@
             "id":1,
             "jsonrpc":"2.0",
             "error":{
-                "code":-32000,
+                "code":-32602,
                 "message":"rlp: value size exceeds available input length"
             }
         }

--- a/integration/mainnet/eth_sendRawTransaction/test_03.json
+++ b/integration/mainnet/eth_sendRawTransaction/test_03.json
@@ -12,7 +12,7 @@
             "id":1,
             "jsonrpc":"2.0",
             "error":{
-                "code":-32000,
+                "code":-32602,
                 "message":"rlp: value size exceeds available input length"
             }
         }


### PR DESCRIPTION
## What
Change the expected error `code` from `-32000` to `-32602` on the four `eth_sendRawTransaction` fixtures that submit undecodable payloads. Error **messages are unchanged**.

- `integration/mainnet/eth_sendRawTransaction/test_01.json` (truncated long-RLP tx)
- `integration/mainnet/eth_sendRawTransaction/test_02.json` (`0xd4`, truncated short-list)
- `integration/mainnet/eth_sendRawTransaction/test_03.json` (`0xd4`)
- `integration/arb-sepolia/eth_sendRawTransaction/test_01.json` (`0xdeadbeef`)

## Why
A malformed/undecodable raw transaction is a parameter-decode failure, which per JSON-RPC 2.0 is `-32602` (invalid params), not `-32000`. Clients currently diverge on the decode class; these PRs align it to `-32602`:

- ethereum/go-ethereum#35129
- erigontech/erigon#21701 (needs these fixtures to go green)
- NethermindEth/nethermind#11921

## Merge gates (why this is a draft)
1. **Must not merge until ethereum/go-ethereum#35129 lands** — until canonical geth emits `-32602`, flipping these shared fixtures turns the daily geth comparison runs red.
2. Pairs with erigontech/erigon#21701, which bumps `RPC_VERSION` to the tag cut here.

