### PR TITLE
add latest-block tests for optional block param on state methods

### DIFF
--- a/integration/mainnet/eth_getBalance/test_29.json
+++ b/integration/mainnet/eth_getBalance/test_29.json
@@ -1,0 +1,23 @@
+[
+    {
+        "request": {
+            "id": 1,
+            "jsonrpc": "2.0",
+            "method": "eth_getBalance",
+            "params": [
+                "0x0000000000000000000000000000000000000000"
+            ]
+        },
+        "response": {
+            "id": 1,
+            "jsonrpc": "2.0"
+        },
+        "test": {
+            "description": "invoke getBalance with omitted block parameter (should default to latest)",
+            "reference": "https://github.com/erigontech/erigon/pull/21586"
+        },
+        "metadata": {
+            "latest": true
+        }
+    }
+]

--- a/integration/mainnet/eth_getCode/test_08.json
+++ b/integration/mainnet/eth_getCode/test_08.json
@@ -1,0 +1,23 @@
+[
+    {
+        "request": {
+            "id": 1,
+            "jsonrpc": "2.0",
+            "method": "eth_getCode",
+            "params": [
+                "0xBB9bc244D798123fDe783fCc1C72d3Bb8C189413"
+            ]
+        },
+        "response": {
+            "id": 1,
+            "jsonrpc": "2.0"
+        },
+        "test": {
+            "description": "invoke getCode with omitted block parameter (should default to latest)",
+            "reference": "https://github.com/erigontech/erigon/pull/21586"
+        },
+        "metadata": {
+            "latest": true
+        }
+    }
+]

--- a/integration/mainnet/eth_getProof/test_27.json
+++ b/integration/mainnet/eth_getProof/test_27.json
@@ -1,0 +1,24 @@
+[
+    {
+        "request": {
+            "id": 1,
+            "jsonrpc": "2.0",
+            "method": "eth_getProof",
+            "params": [
+                "0x8315177aB297bA92A06054cE80a67Ed4DBd7ed3a",
+                []
+            ]
+        },
+        "response": {
+            "id": 1,
+            "jsonrpc": "2.0"
+        },
+        "test": {
+            "description": "invoke getProof with omitted block parameter (should default to latest)",
+            "reference": "https://github.com/erigontech/erigon/pull/21586"
+        },
+        "metadata": {
+            "latest": true
+        }
+    }
+]

--- a/integration/mainnet/eth_getStorageAt/test_11.json
+++ b/integration/mainnet/eth_getStorageAt/test_11.json
@@ -1,0 +1,24 @@
+[
+    {
+        "request": {
+            "id": 1,
+            "jsonrpc": "2.0",
+            "method": "eth_getStorageAt",
+            "params": [
+                "0xc1cadaffffffffffffffffffffffffffffffffff",
+                "0x0100000000000000000000000000000000000000000000000000000000000000"
+            ]
+        },
+        "response": {
+            "id": 1,
+            "jsonrpc": "2.0"
+        },
+        "test": {
+            "description": "invoke getStorageAt with omitted block parameter (should default to latest)",
+            "reference": "https://github.com/erigontech/erigon/pull/21586"
+        },
+        "metadata": {
+            "latest": true
+        }
+    }
+]

--- a/integration/mainnet/eth_getStorageValues/test_11.json
+++ b/integration/mainnet/eth_getStorageValues/test_11.json
@@ -1,0 +1,23 @@
+[
+    {
+        "request": {
+            "id": 1,
+            "jsonrpc": "2.0",
+            "method": "eth_getStorageValues",
+            "params": [
+                {"0x6C8f2A135f6ed072DE4503Bd7C4999a1a17F824B": ["0x0000000000000000000000000000000000000000000000000000000000000001"]}
+            ]
+        },
+        "response": {
+            "id": 1,
+            "jsonrpc": "2.0"
+        },
+        "test": {
+            "description": "invoke getStorageValues with omitted block parameter (should default to latest)",
+            "reference": "https://github.com/erigontech/erigon/pull/21586"
+        },
+        "metadata": {
+            "latest": true
+        }
+    }
+]

--- a/integration/mainnet/eth_getTransactionCount/test_09.json
+++ b/integration/mainnet/eth_getTransactionCount/test_09.json
@@ -1,0 +1,23 @@
+[
+    {
+        "request": {
+            "id": 1,
+            "jsonrpc": "2.0",
+            "method": "eth_getTransactionCount",
+            "params": [
+                "0x2Fc617E933a52713247CE25730f6695920B3befe"
+            ]
+        },
+        "response": {
+            "id": 1,
+            "jsonrpc": "2.0"
+        },
+        "test": {
+            "description": "invoke getTransactionCount with omitted block parameter (should default to latest)",
+            "reference": "https://github.com/erigontech/erigon/pull/21586"
+        },
+        "metadata": {
+            "latest": true
+        }
+    }
+]


### PR DESCRIPTION
Tests for erigontech/erigon#21586: 
* eth_getBalance, 
* eth_getCode, 
*  eth_getStorageAt,
*  eth_getTransactionCount, 
* eth_getProof,
*  eth_getStorageValues now accept an omitted block parameter (defaults to latest). 

Each fixture omits the block param and carries metadata.latest=true