### PR TITLE
integration-test: latest test are processed with batch block 

### DIFF
--- a/cmd/integration/main.go
+++ b/cmd/integration/main.go
@@ -39,6 +39,9 @@ func parseFlags(cfg *config.Config) error {
 	testOnLatest := flag.Bool("L", false, "run only tests on latest block")
 	flag.BoolVar(testOnLatest, "tests-on-latest-block", false, "run only tests on latest block")
 
+	latestBatchSize := flag.Int("N", cfg.LatestBatchSize, "tests per sync check for -L (0=all at once)")
+	flag.IntVar(latestBatchSize, "latest-batch-size", cfg.LatestBatchSize, "tests per sync check for -L (0=all at once)")
+
 	commitmentHistory := flag.Bool("C", false, "include tests requiring commitment history (erigon.request-commitment-history=true)")
 	flag.BoolVar(commitmentHistory, "erigon.commitment-history", false, "include tests requiring commitment history (erigon.request-commitment-history=true)")
 
@@ -143,6 +146,7 @@ func parseFlags(cfg *config.Config) error {
 	cfg.WithoutCompareResults = *withoutCompare
 	cfg.DoNotCompareError = *doNotCompareError
 	cfg.TestsOnLatestBlock = *testOnLatest
+	cfg.LatestBatchSize = *latestBatchSize
 	cfg.CommitmentHistory = *commitmentHistory
 	cfg.MaxFailures = *maxFailures
 	cfg.ReportFile = *reportFile
@@ -231,6 +235,7 @@ func usage() {
 	fmt.Println("  -w, --waiting-time <ms>              wait time after test execution in milliseconds")
 	fmt.Println("  -S, --serial                         all tests run in serial way [default: parallel]")
 	fmt.Println("  -L, --tests-on-latest-block          runs only test on latest block")
+	fmt.Println("  -N, --latest-batch-size <n>          tests per sync check for -L (0=all at once) [default: 50]")
 	fmt.Println("  -C, --erigon.commitment-history       include tests requiring commitment history [default: skip]")
 	fmt.Println("  -M, --max-failures <n>               stop after n failures, 0 = unlimited [default: 100]")
 	fmt.Println("  -R, --report-file <file>             write summary report to file (.csv or .txt)")

--- a/integration/README.md
+++ b/integration/README.md
@@ -53,6 +53,7 @@ Options:
   -w, --waiting-time <ms>              wait time after test execution in milliseconds
   -S, --serial                         all tests run in serial way [default: parallel]
   -L, --tests-on-latest-block          runs only test on latest block
+  -N, --latest-batch-size <n>          tests per sync check for -L (0=all at once) [default: 50]
   -C, --erigon.commitment-history       include tests requiring commitment history [default: skip]
   -M, --max-failures <n>               stop after n failures, 0 = unlimited [default: 100]
   -R, --report-file <file>             write summary report to file (.csv or .txt)
@@ -244,6 +245,34 @@ When the limit is reached the runner prints:
 ```
 ABORTED: too many failures (100), test sequence stopped early
 ```
+
+### Run latest-block tests with sync gating
+
+Tests marked `"latest": true` in their fixture query the chain's current head rather than a
+fixed historical block. When comparing two live nodes with `-e` or `-d`, the nodes must agree
+on the same head block before results are comparable. Use `-L` together with `-e` or `-d` to
+run only these tests; `-N` controls how many tests are dispatched between sync checks:
+
+```bash
+# Default: 50 tests per batch, sync check before each batch
+./build/bin/rpc_int -L -e https://mainnet.infura.io/v3/<key>
+
+# Stricter: one test at a time, sync check before every single test
+./build/bin/rpc_int -L -e https://mainnet.infura.io/v3/<key> -N 1
+
+# No batching: single sync at startup then all tests at once
+./build/bin/rpc_int -L -e https://mainnet.infura.io/v3/<key> -N 0
+```
+
+The runner prints a progress header before each batch:
+```
+Latest batch 1/5 (50 tests)
+...
+Latest batch 2/5 (50 tests)
+...
+```
+
+If the two nodes fail to agree on the same block number within 10 retries the run is aborted.
 
 ### Run CI tests with Erigon
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -117,6 +117,9 @@ type Config struct {
 	// Failure cap
 	MaxFailures int // stop after this many failures (0 = unlimited)
 
+	// Latest-block batching
+	LatestBatchSize int // tests per sync-gated batch when -L + -e/-d (0 = all at once)
+
 	// Report
 	ReportFile string
 
@@ -147,6 +150,7 @@ func NewConfig() *Config {
 		TransportType:     TransportHTTP,
 		ResultsDir:        ResultsDir,
 		MaxFailures:       100,
+		LatestBatchSize:   50,
 	}
 }
 

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -109,6 +109,9 @@ func Run(ctx context.Context, cancelCtx context.CancelFunc, cfg *config.Config) 
 			numBatches := (total + batchSize - 1) / batchSize
 			attempt := 1
 			for i := 0; i < numBatches; {
+				if ctx.Err() != nil || maxFailuresReached(cfg, stats) {
+					break
+				}
 				start := i * batchSize
 				batch := allTests[start:min(start+batchSize, total)]
 				fmt.Fprintf(w, "Attempt %d — Latest batch %d/%d (%d tests)\n", attempt, i+1, numBatches, len(batch))
@@ -120,7 +123,7 @@ func Run(ctx context.Context, cancelCtx context.CancelFunc, cfg *config.Config) 
 				}
 				failuresBefore := stats.FailedTests
 				runTestSlice(ctx, cancelCtx, batch, cfg, clients, numWorkers, stats, w, &reportEntries, &reportMu)
-				if stats.FailedTests > failuresBefore && ctx.Err() == nil && !maxFailuresReached(cfg, stats) {
+				if stats.FailedTests > failuresBefore {
 					fmt.Fprintf(w, "Batch %d/%d had failures, restarting from batch 1\n", i+1, numBatches)
 					w.Flush()
 					i = 0

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -108,6 +108,12 @@ func Run(ctx context.Context, cancelCtx context.CancelFunc, cfg *config.Config) 
 			total := len(allTests)
 			numBatches := (total + batchSize - 1) / batchSize
 			attempt := 1
+			// Snapshot taken after collection (ScheduledTests/SkippedTests already set).
+			// Restored on restart so the final summary reflects only the last attempt.
+			statsSnapshot := *stats
+			reportMu.Lock()
+			reportLenSnapshot := len(reportEntries)
+			reportMu.Unlock()
 			for i := 0; i < numBatches; {
 				if ctx.Err() != nil || maxFailuresReached(cfg, stats) {
 					break
@@ -126,6 +132,10 @@ func Run(ctx context.Context, cancelCtx context.CancelFunc, cfg *config.Config) 
 				if stats.FailedTests > failuresBefore {
 					fmt.Fprintf(w, "Batch %d/%d had failures, restarting from batch 1\n", i+1, numBatches)
 					w.Flush()
+					*stats = statsSnapshot
+					reportMu.Lock()
+					reportEntries = reportEntries[:reportLenSnapshot]
+					reportMu.Unlock()
 					i = 0
 					attempt++
 				} else {

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -107,10 +107,11 @@ func Run(ctx context.Context, cancelCtx context.CancelFunc, cfg *config.Config) 
 			batchSize := cfg.LatestBatchSize
 			total := len(allTests)
 			numBatches := (total + batchSize - 1) / batchSize
+			attempt := 1
 			for i := 0; i < numBatches; {
 				start := i * batchSize
 				batch := allTests[start:min(start+batchSize, total)]
-				fmt.Fprintf(w, "Latest batch %d/%d (%d tests)\n", i+1, numBatches, len(batch))
+				fmt.Fprintf(w, "Attempt %d — Latest batch %d/%d (%d tests)\n", attempt, i+1, numBatches, len(batch))
 				w.Flush()
 				if cfg.VerifyWithDaemon {
 					if err := syncLatestBlock(cfg); err != nil {
@@ -123,6 +124,7 @@ func Run(ctx context.Context, cancelCtx context.CancelFunc, cfg *config.Config) 
 					fmt.Fprintf(w, "Batch %d/%d had failures, restarting from batch 1\n", i+1, numBatches)
 					w.Flush()
 					i = 0
+					attempt++
 				} else {
 					i++
 				}

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -107,7 +107,7 @@ func Run(ctx context.Context, cancelCtx context.CancelFunc, cfg *config.Config) 
 			batchSize := cfg.LatestBatchSize
 			total := len(allTests)
 			numBatches := (total + batchSize - 1) / batchSize
-			for i := 0; i*batchSize < total; i++ {
+			for i := 0; i < numBatches; {
 				start := i * batchSize
 				batch := allTests[start:min(start+batchSize, total)]
 				fmt.Fprintf(w, "Latest batch %d/%d (%d tests)\n", i+1, numBatches, len(batch))
@@ -117,7 +117,15 @@ func Run(ctx context.Context, cancelCtx context.CancelFunc, cfg *config.Config) 
 						return -1, err
 					}
 				}
+				failuresBefore := stats.FailedTests
 				runTestSlice(ctx, cancelCtx, batch, cfg, clients, numWorkers, stats, w, &reportEntries, &reportMu)
+				if stats.FailedTests > failuresBefore && ctx.Err() == nil && !maxFailuresReached(cfg, stats) {
+					fmt.Fprintf(w, "Batch %d/%d had failures, restarting from batch 1\n", i+1, numBatches)
+					w.Flush()
+					i = 0
+				} else {
+					i++
+				}
 			}
 		} else {
 			// N=0: optional single sync then run all.

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -213,7 +213,7 @@ func maxFailuresReached(cfg *config.Config, stats *Stats) bool {
 func syncLatestBlock(cfg *config.Config) error {
 	server1 := fmt.Sprintf("%s:%d", cfg.DaemonOnHost, cfg.ServerPort)
 	latestBlock, err := internalrpc.GetConsistentLatestBlock(
-		cfg.VerboseLevel, server1, cfg.ExternalProviderURL, 10, 1*time.Second)
+		cfg.VerboseLevel, server1, cfg.ExternalProviderURL, 20, 1*time.Second)
 	if err != nil {
 		fmt.Println("sync on latest block number failed ", err)
 		return err

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -38,20 +38,6 @@ func Run(ctx context.Context, cancelCtx context.CancelFunc, cfg *config.Config) 
 		fmt.Println("Run tests using compression")
 	}
 
-	// Handle latest block sync for verify mode
-	if cfg.VerifyWithDaemon && cfg.TestsOnLatestBlock {
-		server1 := fmt.Sprintf("%s:%d", cfg.DaemonOnHost, cfg.ServerPort)
-		latestBlock, err := internalrpc.GetConsistentLatestBlock(
-			cfg.VerboseLevel, server1, cfg.ExternalProviderURL, 10, 1*time.Second)
-		if err != nil {
-			fmt.Println("sync on latest block number failed ", err)
-			return -1, err
-		}
-		if cfg.VerboseLevel > 0 {
-			fmt.Printf("Latest block number for %s, %s: %d\n", server1, cfg.ExternalProviderURL, latestBlock)
-		}
-	}
-
 	if err := cfg.CleanOutputDir(); err != nil {
 		return -1, err
 	}
@@ -94,11 +80,12 @@ func Run(ctx context.Context, cancelCtx context.CancelFunc, cfg *config.Config) 
 	}
 
 	availableTestedAPIs := discovery.TotalAPIs
-	globalTestNumber := 0
 	stats := &Stats{}
 
 	var reportEntries []reportEntry
 	var reportMu sync.Mutex
+
+	transportTypes := cfg.TransportTypes()
 
 	// Each loop iteration runs as a complete batch: all tests are scheduled,
 	// workers drain the channel, results are collected, then the next iteration starts.
@@ -111,142 +98,37 @@ func Run(ctx context.Context, cancelCtx context.CancelFunc, cfg *config.Config) 
 			fmt.Printf("\nTest iteration: %d\n", loopNum+1)
 		}
 
-		testsChan := make(chan *testdata.TestDescriptor, 2000)
-		resultsChan := make(chan testdata.TestResult, 2000)
+		// Phase 1: collect all tests for this iteration (handles skip reporting as side-effect).
+		allTests := collectTestDescriptors(ctx, discovery, f, cfg, transportTypes, stats, &reportEntries, &reportMu)
 
-		var wg sync.WaitGroup
-		for range numWorkers {
-			wg.Add(1)
-			go func() {
-				defer wg.Done()
-				for {
-					select {
-					case test := <-testsChan:
-						if test == nil {
-							return
-						}
-						testOutcome := RunTest(ctx, test, cfg, clients[test.TransportType])
-						resultsChan <- testdata.TestResult{Outcome: testOutcome, Test: test}
-					case <-ctx.Done():
-						return
+		// Phase 2: execute — batched with per-batch sync, or all at once.
+		w := bufio.NewWriterSize(os.Stdout, 64*1024)
+		if cfg.TestsOnLatestBlock && cfg.LatestBatchSize > 0 {
+			batchSize := cfg.LatestBatchSize
+			total := len(allTests)
+			numBatches := (total + batchSize - 1) / batchSize
+			for i := 0; i*batchSize < total; i++ {
+				start := i * batchSize
+				batch := allTests[start:min(start+batchSize, total)]
+				fmt.Fprintf(w, "Latest batch %d/%d (%d tests)\n", i+1, numBatches, len(batch))
+				w.Flush()
+				if cfg.VerifyWithDaemon {
+					if err := syncLatestBlock(cfg); err != nil {
+						return -1, err
 					}
 				}
-			}()
-		}
-
-		var resultsWg sync.WaitGroup
-		resultsWg.Add(1)
-		go func() {
-			defer resultsWg.Done()
-			w := bufio.NewWriterSize(os.Stdout, 64*1024)
-			defer w.Flush()
-			pending := make(map[int]testdata.TestResult)
-			nextIndex := 0
-			for {
-				select {
-				case result, ok := <-resultsChan:
-					if !ok {
-						return
-					}
-					pending[result.Test.Index] = result
-					// Flush all consecutive results starting from nextIndex
-					for {
-						r, exists := pending[nextIndex]
-						if !exists {
-							break
-						}
-						delete(pending, nextIndex)
-						nextIndex++
-						printResult(w, &r, stats, cfg, cancelCtx, &reportEntries, &reportMu)
-						if cfg.ExitOnFail && stats.FailedTests > 0 {
-							return
-						}
-						if maxFailuresReached(cfg, stats) {
-							return
-						}
-					}
-				case <-ctx.Done():
-					return
+				runTestSlice(ctx, cancelCtx, batch, cfg, clients, numWorkers, stats, w, &reportEntries, &reportMu)
+			}
+		} else {
+			// N=0: optional single sync then run all.
+			if cfg.VerifyWithDaemon && cfg.TestsOnLatestBlock {
+				if err := syncLatestBlock(cfg); err != nil {
+					return -1, err
 				}
 			}
-		}()
-
-		// Schedule all tests for this iteration
-		scheduledIndex := 0
-		transportTypes := cfg.TransportTypes()
-	transportLoop:
-		for _, transportType := range transportTypes {
-			testNumberInAnyLoop := 1
-			globalTestNumber = 0
-
-			for _, tc := range discovery.Tests {
-				if ctx.Err() != nil {
-					break transportLoop
-				}
-
-				globalTestNumber = tc.Number
-				currAPI := tc.APIName
-				jsonTestFullName := tc.Name
-				testName := strings.TrimPrefix(jsonTestFullName, currAPI+"/")
-				if idx := strings.LastIndex(jsonTestFullName, "/"); idx >= 0 {
-					testName = jsonTestFullName[idx+1:]
-				}
-
-				if f.APIUnderTest(currAPI, jsonTestFullName, tc.Latest, tc.CommitmentHistory) {
-					if f.IsSkipped(currAPI, jsonTestFullName, testNumberInAnyLoop) {
-						if IsStartTestReached(cfg, testNumberInAnyLoop) {
-							if !cfg.DisplayOnlyFail && cfg.ReqTestNum == -1 {
-								file := fmt.Sprintf("%-60s", jsonTestFullName)
-								tt := fmt.Sprintf("%-15s", transportType)
-								fmt.Printf("%04d. %s::%s   skipped\n", testNumberInAnyLoop, tt, file)
-							}
-							stats.SkippedTests++
-							if cfg.VerboseLevel == 1 || cfg.ReportFile != "" {
-								reportMu.Lock()
-								reportEntries = append(reportEntries, reportEntry{
-									TestNumber:    testNumberInAnyLoop,
-									TransportType: transportType,
-									TestName:      jsonTestFullName,
-									Result:        "SKIPPED",
-									ErrorMessage:  "",
-								})
-								reportMu.Unlock()
-							}
-						}
-					} else {
-						shouldRun := ShouldRunTest(cfg, testName, testNumberInAnyLoop)
-
-						if shouldRun && IsStartTestReached(cfg, testNumberInAnyLoop) {
-							testDesc := &testdata.TestDescriptor{
-								Name:          jsonTestFullName,
-								Number:        testNumberInAnyLoop,
-								TransportType: transportType,
-								Index:         scheduledIndex,
-							}
-							scheduledIndex++
-							select {
-							case <-ctx.Done():
-								break transportLoop
-							case testsChan <- testDesc:
-							}
-							stats.ScheduledTests++
-
-							if cfg.WaitingTime > 0 {
-								time.Sleep(time.Duration(cfg.WaitingTime) * time.Millisecond)
-							}
-						}
-					}
-				}
-
-				testNumberInAnyLoop++
-			}
+			runTestSlice(ctx, cancelCtx, allTests, cfg, clients, numWorkers, stats, w, &reportEntries, &reportMu)
 		}
-
-		// Wait for this iteration to fully complete before starting the next
-		close(testsChan)
-		wg.Wait()
-		close(resultsChan)
-		resultsWg.Wait()
+		w.Flush()
 	}
 
 	if stats.ScheduledTests == 0 && cfg.TestingAPIsWith != "" {
@@ -275,7 +157,7 @@ func Run(ctx context.Context, cancelCtx context.CancelFunc, cfg *config.Config) 
 
 	// Print summary
 	elapsed := time.Since(startTime)
-	stats.PrintSummary(startTime, elapsed, cfg.LoopNumber, availableTestedAPIs, globalTestNumber)
+	stats.PrintSummary(startTime, elapsed, cfg.LoopNumber, availableTestedAPIs, discovery.TotalTests)
 
 	reportMu.Lock()
 	entries := reportEntries
@@ -284,7 +166,7 @@ func Run(ctx context.Context, cancelCtx context.CancelFunc, cfg *config.Config) 
 	// Generate JSON report when verbose == 1 (mirrors Python behaviour)
 	if cfg.VerboseLevel == 1 {
 		reportFile := filepath.Join(cfg.OutputDir, "test_report.json")
-		if err := generateReport(reportFile, startTime, elapsed, stats, globalTestNumber, availableTestedAPIs, cfg.LoopNumber, entries); err != nil {
+		if err := generateReport(reportFile, startTime, elapsed, stats, discovery.TotalTests, availableTestedAPIs, cfg.LoopNumber, entries); err != nil {
 			fmt.Fprintf(os.Stderr, "Warning: failed to generate report: %v\n", err)
 		} else {
 			fmt.Printf("\nJSON report generated: %s\n", reportFile)
@@ -312,6 +194,183 @@ func Run(ctx context.Context, cancelCtx context.CancelFunc, cfg *config.Config) 
 
 func maxFailuresReached(cfg *config.Config, stats *Stats) bool {
 	return cfg.MaxFailures > 0 && stats.FailedTests >= cfg.MaxFailures
+}
+
+// syncLatestBlock waits until both nodes agree on the latest block number.
+func syncLatestBlock(cfg *config.Config) error {
+	server1 := fmt.Sprintf("%s:%d", cfg.DaemonOnHost, cfg.ServerPort)
+	latestBlock, err := internalrpc.GetConsistentLatestBlock(
+		cfg.VerboseLevel, server1, cfg.ExternalProviderURL, 10, 1*time.Second)
+	if err != nil {
+		fmt.Println("sync on latest block number failed ", err)
+		return err
+	}
+	if cfg.VerboseLevel > 0 {
+		fmt.Printf("Latest block number for %s, %s: %d\n", server1, cfg.ExternalProviderURL, latestBlock)
+	}
+	return nil
+}
+
+// collectTestDescriptors runs the filter/skip logic over the discovered tests and returns
+// descriptors ready for execution. Skip reporting and stats are handled as side-effects.
+func collectTestDescriptors(
+	ctx context.Context,
+	discovery *testdata.DiscoveryResult,
+	f *filter.TestFilter,
+	cfg *config.Config,
+	transportTypes []string,
+	stats *Stats,
+	reportEntries *[]reportEntry,
+	reportMu *sync.Mutex,
+) []*testdata.TestDescriptor {
+	var all []*testdata.TestDescriptor
+
+outer:
+	for _, transportType := range transportTypes {
+		testNumberInAnyLoop := 1
+		for _, tc := range discovery.Tests {
+			if ctx.Err() != nil {
+				break outer
+			}
+			currAPI := tc.APIName
+			jsonTestFullName := tc.Name
+			testName := jsonTestFullName
+			if idx := strings.LastIndex(jsonTestFullName, "/"); idx >= 0 {
+				testName = jsonTestFullName[idx+1:]
+			}
+
+			if f.APIUnderTest(currAPI, jsonTestFullName, tc.Latest, tc.CommitmentHistory) {
+				if f.IsSkipped(currAPI, jsonTestFullName, testNumberInAnyLoop) {
+					if IsStartTestReached(cfg, testNumberInAnyLoop) {
+						if !cfg.DisplayOnlyFail && cfg.ReqTestNum == -1 {
+							file := fmt.Sprintf("%-60s", jsonTestFullName)
+							tt := fmt.Sprintf("%-15s", transportType)
+							fmt.Printf("%04d. %s::%s   skipped\n", testNumberInAnyLoop, tt, file)
+						}
+						stats.SkippedTests++
+						if cfg.VerboseLevel == 1 || cfg.ReportFile != "" {
+							reportMu.Lock()
+							*reportEntries = append(*reportEntries, reportEntry{
+								TestNumber:    testNumberInAnyLoop,
+								TransportType: transportType,
+								TestName:      jsonTestFullName,
+								Result:        "SKIPPED",
+								ErrorMessage:  "",
+							})
+							reportMu.Unlock()
+						}
+					}
+				} else if ShouldRunTest(cfg, testName, testNumberInAnyLoop) && IsStartTestReached(cfg, testNumberInAnyLoop) {
+					all = append(all, &testdata.TestDescriptor{
+						Name:          jsonTestFullName,
+						Number:        testNumberInAnyLoop,
+						TransportType: transportType,
+					})
+					stats.ScheduledTests++
+				}
+			}
+			testNumberInAnyLoop++
+		}
+	}
+	return all
+}
+
+// runTestSlice executes a slice of tests through the worker pool and blocks until all complete.
+// It re-indexes tests from 0 for ordered output within the slice.
+func runTestSlice(
+	ctx context.Context,
+	cancelCtx context.CancelFunc,
+	tests []*testdata.TestDescriptor,
+	cfg *config.Config,
+	clients map[string]*internalrpc.Client,
+	numWorkers int,
+	stats *Stats,
+	w *bufio.Writer,
+	reportEntries *[]reportEntry,
+	reportMu *sync.Mutex,
+) {
+	if len(tests) == 0 {
+		return
+	}
+	for i, td := range tests {
+		td.Index = i
+	}
+
+	bufSize := min(len(tests), 2000)
+	testsChan := make(chan *testdata.TestDescriptor, bufSize)
+	resultsChan := make(chan testdata.TestResult, bufSize)
+
+	var wg sync.WaitGroup
+	for range numWorkers {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				select {
+				case test := <-testsChan:
+					if test == nil {
+						return
+					}
+					testOutcome := RunTest(ctx, test, cfg, clients[test.TransportType])
+					resultsChan <- testdata.TestResult{Outcome: testOutcome, Test: test}
+				case <-ctx.Done():
+					return
+				}
+			}
+		}()
+	}
+
+	var resultsWg sync.WaitGroup
+	resultsWg.Add(1)
+	go func() {
+		defer resultsWg.Done()
+		pending := make(map[int]testdata.TestResult)
+		nextIndex := 0
+		for {
+			select {
+			case result, ok := <-resultsChan:
+				if !ok {
+					return
+				}
+				pending[result.Test.Index] = result
+				for {
+					r, exists := pending[nextIndex]
+					if !exists {
+						break
+					}
+					delete(pending, nextIndex)
+					nextIndex++
+					printResult(w, &r, stats, cfg, cancelCtx, reportEntries, reportMu)
+					if cfg.ExitOnFail && stats.FailedTests > 0 {
+						return
+					}
+					if maxFailuresReached(cfg, stats) {
+						return
+					}
+				}
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+
+schedLoop:
+	for _, td := range tests {
+		select {
+		case <-ctx.Done():
+			break schedLoop
+		case testsChan <- td:
+		}
+		if cfg.WaitingTime > 0 {
+			time.Sleep(time.Duration(cfg.WaitingTime) * time.Millisecond)
+		}
+	}
+
+	close(testsChan)
+	wg.Wait()
+	close(resultsChan)
+	resultsWg.Wait()
+	fmt.Fprintln(w)
 }
 
 func printResult(w *bufio.Writer, result *testdata.TestResult, stats *Stats, cfg *config.Config, cancelCtx context.CancelFunc, reportEntries *[]reportEntry, reportMu *sync.Mutex) {

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -107,20 +107,13 @@ func Run(ctx context.Context, cancelCtx context.CancelFunc, cfg *config.Config) 
 			batchSize := cfg.LatestBatchSize
 			total := len(allTests)
 			numBatches := (total + batchSize - 1) / batchSize
-			attempt := 1
-			// Snapshot taken after collection (ScheduledTests/SkippedTests already set).
-			// Restored on restart so the final summary reflects only the last attempt.
-			statsSnapshot := *stats
-			reportMu.Lock()
-			reportLenSnapshot := len(reportEntries)
-			reportMu.Unlock()
-			for i := 0; i < numBatches; {
+			for i := range numBatches {
 				if ctx.Err() != nil || maxFailuresReached(cfg, stats) {
 					break
 				}
 				start := i * batchSize
 				batch := allTests[start:min(start+batchSize, total)]
-				fmt.Fprintf(w, "Attempt %d — Latest batch %d/%d (%d tests)\n", attempt, i+1, numBatches, len(batch))
+				fmt.Fprintf(w, "Latest batch %d/%d (%d tests)\n", i+1, numBatches, len(batch))
 				w.Flush()
 				if cfg.VerifyWithDaemon {
 					if err := syncLatestBlock(cfg); err != nil {
@@ -130,16 +123,9 @@ func Run(ctx context.Context, cancelCtx context.CancelFunc, cfg *config.Config) 
 				failuresBefore := stats.FailedTests
 				runTestSlice(ctx, cancelCtx, batch, cfg, clients, numWorkers, stats, w, &reportEntries, &reportMu)
 				if stats.FailedTests > failuresBefore {
-					fmt.Fprintf(w, "Batch %d/%d had failures, restarting from batch 1\n", i+1, numBatches)
+					fmt.Fprintf(w, "Latest batch %d/%d had failures, stopping\n", i+1, numBatches)
 					w.Flush()
-					*stats = statsSnapshot
-					reportMu.Lock()
-					reportEntries = reportEntries[:reportLenSnapshot]
-					reportMu.Unlock()
-					i = 0
-					attempt++
-				} else {
-					i++
+					break
 				}
 			}
 		} else {


### PR DESCRIPTION

When running -L with a live reference node (-e/-L), tests are now dispatched in batches of N (default 50) with a sync check before each batch. N=0 keeps the previous behaviour (single sync then all at once).