### PR TITLE
Fix flaky latest tests: concurrent dispatch and head classification

### DIFF
--- a/cmd/integration/main.go
+++ b/cmd/integration/main.go
@@ -113,6 +113,8 @@ func parseFlags(cfg *config.Config) error {
 
 	syncRetries := flag.Int("sync-retries", cfg.SyncRetries, "max attempts waiting for testing/reference node block alignment (1s between attempts)")
 
+	latestRetries := flag.Int("latest-retries", cfg.LatestRetries, "max attempts for a failed latest-block test whose nodes changed head during the test (1 = classify only, 0 = off)")
+
 	reportFile := flag.String("R", "", "write CSV summary report to file")
 	flag.StringVar(reportFile, "report-file", "", "write CSV summary report to file")
 
@@ -152,6 +154,7 @@ func parseFlags(cfg *config.Config) error {
 	cfg.CommitmentHistory = *commitmentHistory
 	cfg.MaxFailures = *maxFailures
 	cfg.SyncRetries = *syncRetries
+	cfg.LatestRetries = *latestRetries
 	cfg.ReportFile = *reportFile
 	cfg.CpuProfile = *cpuProfile
 	cfg.MemProfile = *memProfile
@@ -242,6 +245,7 @@ func usage() {
 	fmt.Println("  -C, --erigon.commitment-history       include tests requiring commitment history [default: skip]")
 	fmt.Println("  -M, --max-failures <n>               stop after n failures, 0 = unlimited [default: 100]")
 	fmt.Println("      --sync-retries <n>               max attempts waiting for node block alignment, 1s apart [default: 300]")
+	fmt.Println("      --latest-retries <n>             max attempts for a failed latest test whose nodes changed head, 1 = classify only, 0 = off [default: 3]")
 	fmt.Println("  -R, --report-file <file>             write summary report to file (.csv or .txt)")
 	fmt.Println("      --cpuprofile <file>              write cpu profile to file")
 	fmt.Println("      --memprofile <file>              write memory profile to file")

--- a/integration/README.md
+++ b/integration/README.md
@@ -57,6 +57,7 @@ Options:
   -C, --erigon.commitment-history       include tests requiring commitment history [default: skip]
   -M, --max-failures <n>               stop after n failures, 0 = unlimited [default: 100]
       --sync-retries <n>               max attempts waiting for node block alignment, 1s apart [default: 300]
+      --latest-retries <n>             max attempts for a failed latest test whose nodes changed head, 1 = classify only, 0 = off [default: 3]
   -R, --report-file <file>             write summary report to file (.csv or .txt)
       --cpuprofile <file>              write cpu profile to file
       --memprofile <file>              write memory profile to file
@@ -274,6 +275,31 @@ Latest batch 2/5 (50 tests)
 ```
 
 If the two nodes fail to agree on the same block number within 10 retries the run is aborted.
+
+#### Inconclusive latest-block failures
+
+The batch sync check only tells that the nodes agreed *before* the batch: it cannot pin the
+block, because each node resolves the `latest` tag on its own when the request arrives. Two
+mitigations keep this from turning into a spurious failure:
+
+- In `-e`/`-d` mode both requests are dispatched **concurrently**, so the gap between the two
+  resolutions is no longer the duration of the first response (seconds, for a big tracing
+  response) but only the sub-second skew between the nodes' own head updates.
+- When a `latest` test fails anyway, the runner re-reads the head number and hash on both
+  nodes and compares them with the values read just before the test. If a head moved, the two
+  sides did not trace the same block: the attempt is **inconclusive** and the test is retried
+  in process, without keeping the (potentially huge) response and diff files. Only the head
+  values are logged:
+
+```
+0246. http           ::debug_traceBlockByNumber/test_24.json   failed: json diff mismatch
+      inconclusive attempt 1/3: head moved during test (before: ... after: ...), retrying
+```
+
+  If the heads were stable on both sides, the mismatch is real and reported immediately. After
+  `--latest-retries` attempts (default 3) a persistent skew is reported as a failure with both
+  head values attached as evidence, in the console and in the JSON report. Use
+  `--latest-retries 1` to classify without retrying, or `0` to disable the head check.
 
 ### Run CI tests with Erigon
 

--- a/integration/README.md
+++ b/integration/README.md
@@ -285,21 +285,22 @@ mitigations keep this from turning into a spurious failure:
 - In `-e`/`-d` mode both requests are dispatched **concurrently**, so the gap between the two
   resolutions is no longer the duration of the first response (seconds, for a big tracing
   response) but only the sub-second skew between the nodes' own head updates.
-- When a `latest` test fails anyway, the runner re-reads the head number and hash on both
-  nodes and compares them with the values read just before the test. If a head moved, the two
-  sides did not trace the same block: the attempt is **inconclusive** and the test is retried
-  in process, without keeping the (potentially huge) response and diff files. Only the head
-  values are logged:
+- When the two responses of a `latest` test differ, the runner re-reads the head number and
+  hash on both nodes and compares them with the values read just before the test. If a head
+  moved, the two sides did not trace the same block: the attempt is **inconclusive** and the
+  test is retried in process. The diff is not even computed and no response file is written,
+  so a discarded attempt costs nothing but the head reads; only the head values are logged:
 
 ```
 0246. http           ::debug_traceBlockByNumber/test_24.json   failed: json diff mismatch
       inconclusive attempt 1/3: head moved during test (before: ... after: ...), retrying
 ```
 
-  If the heads were stable on both sides, the mismatch is real and reported immediately. After
-  `--latest-retries` attempts (default 3) a persistent skew is reported as a failure with both
-  head values attached as evidence, in the console and in the JSON report. Use
-  `--latest-retries 1` to classify without retrying, or `0` to disable the head check.
+  If the heads were stable on both sides, the mismatch is real and reported immediately. The
+  last of the `--latest-retries` attempts (default 3) always runs ungated, so a genuine failure
+  still gets its full diff, with both head values attached as evidence in the console and in
+  the JSON report. Use `--latest-retries 1` to classify without retrying, or `0` to disable the
+  head check.
 
 ### Run CI tests with Erigon
 

--- a/internal/compare/comparator.go
+++ b/internal/compare/comparator.go
@@ -39,12 +39,17 @@ const (
 
 // ProcessResponse compares actual response against expected, handling all "don't care" cases.
 // This is the v2 equivalent of v1's processResponse method.
+// notComparable, when set, is consulted once the two responses are known to differ and
+// before any file is written: if it reports true the responses cannot be compared at all
+// (e.g. the two nodes resolved a block tag to different blocks) and the outcome is marked
+// inconclusive, skipping the dump and the diff.
 func ProcessResponse(
 	response, referenceResponse, responseInFile any,
 	cfg *config.Config,
 	outputDir, daemonFile, expRspFile, diffFile string,
 	outcome *testdata.TestOutcome,
 	ignoreFields []string,
+	notComparable func() bool,
 ) {
 	var expectedResponse any
 	if referenceResponse != nil {
@@ -130,6 +135,13 @@ func ProcessResponse(
 				return
 			}
 		}
+	}
+
+	// The responses differ: before paying for the dump and the diff, let the caller veto the
+	// comparison. Two responses that answer different questions produce a diff of pure noise.
+	if notComparable != nil && notComparable() {
+		outcome.Inconclusive = true
+		return
 	}
 
 	// Detailed comparison: dump files and run diff

--- a/internal/compare/comparator_bench_test.go
+++ b/internal/compare/comparator_bench_test.go
@@ -53,7 +53,7 @@ func BenchmarkProcessResponse_ExactMatch(b *testing.B) {
 	b.ResetTimer()
 	for b.Loop() {
 		outcome := &testdata.TestOutcome{}
-		ProcessResponse(response, nil, expected, cfg, dir, "", "", "", outcome, nil)
+		ProcessResponse(response, nil, expected, cfg, dir, "", "", "", outcome, nil, nil)
 	}
 }
 
@@ -72,7 +72,7 @@ func BenchmarkProcessResponse_DiffMismatch_JsonDiffGo(b *testing.B) {
 	b.ResetTimer()
 	for b.Loop() {
 		outcome := &testdata.TestOutcome{}
-		ProcessResponse(response, nil, expected, cfg, dir, daemonFile, expRspFile, diffFile, outcome, nil)
+		ProcessResponse(response, nil, expected, cfg, dir, daemonFile, expRspFile, diffFile, outcome, nil, nil)
 	}
 }
 

--- a/internal/compare/comparator_test.go
+++ b/internal/compare/comparator_test.go
@@ -50,7 +50,7 @@ func TestProcessResponse_WithoutCompare(t *testing.T) {
 	response := map[string]any{"jsonrpc": "2.0", "id": float64(1), "result": "0x1"}
 	expected := map[string]any{"jsonrpc": "2.0", "id": float64(1), "result": "0x2"}
 
-	ProcessResponse(response, nil, expected, cfg, dir, "", "", "", outcome, nil)
+	ProcessResponse(response, nil, expected, cfg, dir, "", "", "", outcome, nil, nil)
 
 	if !outcome.Success {
 		t.Error("WithoutCompareResults should always succeed")
@@ -65,7 +65,7 @@ func TestProcessResponse_ExactMatch(t *testing.T) {
 	response := map[string]any{"jsonrpc": "2.0", "id": float64(1), "result": "0x1"}
 	expected := map[string]any{"jsonrpc": "2.0", "id": float64(1), "result": "0x1"}
 
-	ProcessResponse(response, nil, expected, cfg, dir, "", "", "", outcome, nil)
+	ProcessResponse(response, nil, expected, cfg, dir, "", "", "", outcome, nil, nil)
 
 	if !outcome.Success {
 		t.Errorf("exact match should succeed, error: %v", outcome.Error)
@@ -83,7 +83,7 @@ func TestProcessResponse_NullExpectedResult(t *testing.T) {
 	response := map[string]any{"jsonrpc": "2.0", "id": float64(1), "result": "0xabc"}
 	expected := map[string]any{"jsonrpc": "2.0", "id": float64(1), "result": nil}
 
-	ProcessResponse(response, nil, expected, cfg, dir, "", "", "", outcome, nil)
+	ProcessResponse(response, nil, expected, cfg, dir, "", "", "", outcome, nil, nil)
 
 	if !outcome.Success {
 		t.Errorf("null expected result should be accepted, error: %v", outcome.Error)
@@ -98,7 +98,7 @@ func TestProcessResponse_NullExpectedError(t *testing.T) {
 	response := map[string]any{"jsonrpc": "2.0", "id": float64(1), "error": map[string]any{"code": float64(-32000), "message": "some error"}}
 	expected := map[string]any{"jsonrpc": "2.0", "id": float64(1), "error": nil}
 
-	ProcessResponse(response, nil, expected, cfg, dir, "", "", "", outcome, nil)
+	ProcessResponse(response, nil, expected, cfg, dir, "", "", "", outcome, nil, nil)
 
 	if !outcome.Success {
 		t.Errorf("null expected error should be accepted, error: %v", outcome.Error)
@@ -113,7 +113,7 @@ func TestProcessResponse_EmptyExpected(t *testing.T) {
 	response := map[string]any{"jsonrpc": "2.0", "id": float64(1), "result": "0x1"}
 	expected := map[string]any{"jsonrpc": "2.0", "id": float64(1)}
 
-	ProcessResponse(response, nil, expected, cfg, dir, "", "", "", outcome, nil)
+	ProcessResponse(response, nil, expected, cfg, dir, "", "", "", outcome, nil, nil)
 
 	if !outcome.Success {
 		t.Errorf("empty expected (just jsonrpc+id) should be accepted, error: %v", outcome.Error)
@@ -129,7 +129,7 @@ func TestProcessResponse_DoNotCompareError_SameCode(t *testing.T) {
 	response := map[string]any{"jsonrpc": "2.0", "id": float64(1), "error": map[string]any{"code": float64(-32000), "message": "err1"}}
 	expected := map[string]any{"jsonrpc": "2.0", "id": float64(1), "error": map[string]any{"code": float64(-32000), "message": "err2"}}
 
-	ProcessResponse(response, nil, expected, cfg, dir, "", "", "", outcome, nil)
+	ProcessResponse(response, nil, expected, cfg, dir, "", "", "", outcome, nil, nil)
 
 	if !outcome.Success {
 		t.Errorf("DoNotCompareError should accept same error code with different message, error: %v", outcome.Error)
@@ -150,7 +150,7 @@ func TestProcessResponse_DoNotCompareError_DifferentCode(t *testing.T) {
 	response := map[string]any{"jsonrpc": "2.0", "id": float64(1), "error": map[string]any{"code": float64(-32000), "message": "err1"}}
 	expected := map[string]any{"jsonrpc": "2.0", "id": float64(1), "error": map[string]any{"code": float64(-32001), "message": "err2"}}
 
-	ProcessResponse(response, nil, expected, cfg, dir, daemonFile, expRspFile, diffFile, outcome, nil)
+	ProcessResponse(response, nil, expected, cfg, dir, daemonFile, expRspFile, diffFile, outcome, nil, nil)
 
 	if outcome.Success {
 		t.Error("DoNotCompareError should reject different error codes")
@@ -170,7 +170,7 @@ func TestProcessResponse_DiffMismatch_JsonDiffGo(t *testing.T) {
 	response := map[string]any{"jsonrpc": "2.0", "id": float64(1), "result": "0x1"}
 	expected := map[string]any{"jsonrpc": "2.0", "id": float64(1), "result": "0x2"}
 
-	ProcessResponse(response, nil, expected, cfg, dir, daemonFile, expRspFile, diffFile, outcome, nil)
+	ProcessResponse(response, nil, expected, cfg, dir, daemonFile, expRspFile, diffFile, outcome, nil, nil)
 
 	if outcome.Success {
 		t.Error("mismatched responses should fail")
@@ -194,7 +194,7 @@ func TestProcessResponse_DiffMismatch_SingleTest_HasColoredDiff(t *testing.T) {
 	response := map[string]any{"jsonrpc": "2.0", "id": float64(1), "result": "0x1"}
 	expected := map[string]any{"jsonrpc": "2.0", "id": float64(1), "result": "0x2"}
 
-	ProcessResponse(response, nil, expected, cfg, dir, daemonFile, expRspFile, diffFile, outcome, nil)
+	ProcessResponse(response, nil, expected, cfg, dir, daemonFile, expRspFile, diffFile, outcome, nil, nil)
 
 	if outcome.ColoredDiff == "" {
 		t.Error("single test mode should produce colored diff on mismatch")
@@ -214,7 +214,7 @@ func TestProcessResponse_IgnoreFields_PassesWhenIgnoredFieldsDiffer(t *testing.T
 	response := map[string]any{"jsonrpc": "2.0", "id": float64(1), "result": map[string]any{"value": "0x1", "error": "actual error"}}
 	expected := map[string]any{"jsonrpc": "2.0", "id": float64(1), "result": map[string]any{"value": "0x1", "error": "expected error"}}
 
-	ProcessResponse(response, nil, expected, cfg, dir, daemonFile, expRspFile, diffFile, outcome, []string{"result.error"})
+	ProcessResponse(response, nil, expected, cfg, dir, daemonFile, expRspFile, diffFile, outcome, []string{"result.error"}, nil)
 
 	if !outcome.Success {
 		t.Errorf("ignored field diff should pass, error: %v", outcome.Error)
@@ -234,7 +234,7 @@ func TestProcessResponse_IgnoreFields_FailsOnNonIgnoredDiff(t *testing.T) {
 	response := map[string]any{"jsonrpc": "2.0", "id": float64(1), "result": map[string]any{"value": "0x1", "error": "x"}}
 	expected := map[string]any{"jsonrpc": "2.0", "id": float64(1), "result": map[string]any{"value": "0x2", "error": "y"}}
 
-	ProcessResponse(response, nil, expected, cfg, dir, daemonFile, expRspFile, diffFile, outcome, []string{"result.error"})
+	ProcessResponse(response, nil, expected, cfg, dir, daemonFile, expRspFile, diffFile, outcome, []string{"result.error"}, nil)
 
 	if outcome.Success {
 		t.Error("non-ignored field still differs, should fail")

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -123,6 +123,9 @@ type Config struct {
 	// Node sync convergence
 	SyncRetries int // max attempts waiting for testing/reference node block alignment
 
+	// In-process retries for a failed latest-block test whose nodes moved head under it
+	LatestRetries int
+
 	// Report
 	ReportFile string
 
@@ -155,6 +158,7 @@ func NewConfig() *Config {
 		MaxFailures:       100,
 		LatestBatchSize:   50,
 		SyncRetries:       300,
+		LatestRetries:     3,
 	}
 }
 

--- a/internal/rpc/http.go
+++ b/internal/rpc/http.go
@@ -184,21 +184,23 @@ func validateJsonRpcResponseObject(obj map[string]any) error {
 	return nil
 }
 
-// GetLatestBlockNumber queries eth_blockNumber and returns the result as uint64.
-func GetLatestBlockNumber(ctx context.Context, client *Client, url string) (uint64, Metrics, error) {
-	type rpcReq struct {
+// marshalRequest builds the JSON-RPC 2.0 envelope for a single call.
+func marshalRequest(method string, params ...any) []byte {
+	if params == nil {
+		params = []any{}
+	}
+	request, _ := jsonAPI.Marshal(struct {
 		Jsonrpc string `json:"jsonrpc"`
 		Method  string `json:"method"`
 		Params  []any  `json:"params"`
 		Id      int    `json:"id"`
-	}
+	}{Jsonrpc: "2.0", Method: method, Params: params, Id: 1})
+	return request
+}
 
-	reqBytes, _ := jsonAPI.Marshal(rpcReq{
-		Jsonrpc: "2.0",
-		Method:  "eth_blockNumber",
-		Params:  []any{},
-		Id:      1,
-	})
+// GetLatestBlockNumber queries eth_blockNumber and returns the result as uint64.
+func GetLatestBlockNumber(ctx context.Context, client *Client, url string) (uint64, Metrics, error) {
+	reqBytes := marshalRequest("eth_blockNumber")
 
 	var response any
 	metrics, err := client.Call(ctx, url, reqBytes, &response)
@@ -234,50 +236,33 @@ type Head struct {
 // GetLatestHead queries eth_getBlockByNumber("latest", false) and returns the head
 // number and hash. The hash is what distinguishes a plain head advance from a tip reorg.
 func GetLatestHead(ctx context.Context, client *Client, url string) (Head, Metrics, error) {
-	type rpcReq struct {
-		Jsonrpc string `json:"jsonrpc"`
-		Method  string `json:"method"`
-		Params  []any  `json:"params"`
-		Id      int    `json:"id"`
+	// Only two fields of the header are decoded: the rest of it (logsBloom alone is 514 bytes)
+	// is skipped instead of being boxed into a map.
+	var response struct {
+		Result *struct {
+			Number string `json:"number"`
+			Hash   string `json:"hash"`
+		} `json:"result"`
+		Error jsoniter.RawMessage `json:"error"`
 	}
-
-	reqBytes, _ := jsonAPI.Marshal(rpcReq{
-		Jsonrpc: "2.0",
-		Method:  "eth_getBlockByNumber",
-		Params:  []any{"latest", false},
-		Id:      1,
-	})
-
-	var response any
-	metrics, err := client.Call(ctx, url, reqBytes, &response)
+	metrics, err := client.Call(ctx, url, marshalRequest("eth_getBlockByNumber", "latest", false), &response)
 	if err != nil {
 		return Head{}, metrics, err
 	}
-
-	responseMap, ok := response.(map[string]any)
-	if !ok {
-		return Head{}, metrics, fmt.Errorf("response is not a map: %v", response)
+	if len(response.Error) > 0 {
+		return Head{}, metrics, fmt.Errorf("RPC error: %s", response.Error)
 	}
-	if errorVal, hasError := responseMap["error"]; hasError {
-		return Head{}, metrics, fmt.Errorf("RPC error: %v", errorVal)
+	if response.Result == nil {
+		return Head{}, metrics, fmt.Errorf("no block in response from %s", url)
 	}
-	block, ok := responseMap["result"].(map[string]any)
-	if !ok {
-		return Head{}, metrics, fmt.Errorf("no block in response: %v", responseMap["result"])
+	if response.Result.Number == "" || response.Result.Hash == "" {
+		return Head{}, metrics, fmt.Errorf("block without number or hash: %+v", *response.Result)
 	}
-	numberStr, ok := block["number"].(string)
-	if !ok {
-		return Head{}, metrics, fmt.Errorf("block number is not a string: %v", block["number"])
-	}
-	number, err := parseHexUint64(strings.TrimPrefix(numberStr, "0x"))
+	number, err := parseHexUint64(strings.TrimPrefix(response.Result.Number, "0x"))
 	if err != nil {
 		return Head{}, metrics, err
 	}
-	hash, ok := block["hash"].(string)
-	if !ok {
-		return Head{}, metrics, fmt.Errorf("block hash is not a string: %v", block["hash"])
-	}
-	return Head{Number: number, Hash: hash}, metrics, nil
+	return Head{Number: number, Hash: response.Result.Hash}, metrics, nil
 }
 
 func parseHexUint64(s string) (uint64, error) {

--- a/internal/rpc/http.go
+++ b/internal/rpc/http.go
@@ -225,6 +225,61 @@ func GetLatestBlockNumber(ctx context.Context, client *Client, url string) (uint
 	return 0, metrics, fmt.Errorf("no result or error found in response")
 }
 
+// Head identifies a chain head by block number and block hash.
+type Head struct {
+	Number uint64
+	Hash   string
+}
+
+// GetLatestHead queries eth_getBlockByNumber("latest", false) and returns the head
+// number and hash. The hash is what distinguishes a plain head advance from a tip reorg.
+func GetLatestHead(ctx context.Context, client *Client, url string) (Head, Metrics, error) {
+	type rpcReq struct {
+		Jsonrpc string `json:"jsonrpc"`
+		Method  string `json:"method"`
+		Params  []any  `json:"params"`
+		Id      int    `json:"id"`
+	}
+
+	reqBytes, _ := jsonAPI.Marshal(rpcReq{
+		Jsonrpc: "2.0",
+		Method:  "eth_getBlockByNumber",
+		Params:  []any{"latest", false},
+		Id:      1,
+	})
+
+	var response any
+	metrics, err := client.Call(ctx, url, reqBytes, &response)
+	if err != nil {
+		return Head{}, metrics, err
+	}
+
+	responseMap, ok := response.(map[string]any)
+	if !ok {
+		return Head{}, metrics, fmt.Errorf("response is not a map: %v", response)
+	}
+	if errorVal, hasError := responseMap["error"]; hasError {
+		return Head{}, metrics, fmt.Errorf("RPC error: %v", errorVal)
+	}
+	block, ok := responseMap["result"].(map[string]any)
+	if !ok {
+		return Head{}, metrics, fmt.Errorf("no block in response: %v", responseMap["result"])
+	}
+	numberStr, ok := block["number"].(string)
+	if !ok {
+		return Head{}, metrics, fmt.Errorf("block number is not a string: %v", block["number"])
+	}
+	number, err := parseHexUint64(strings.TrimPrefix(numberStr, "0x"))
+	if err != nil {
+		return Head{}, metrics, err
+	}
+	hash, ok := block["hash"].(string)
+	if !ok {
+		return Head{}, metrics, fmt.Errorf("block hash is not a string: %v", block["hash"])
+	}
+	return Head{Number: number, Hash: hash}, metrics, nil
+}
+
 func parseHexUint64(s string) (uint64, error) {
 	var result uint64
 	for _, c := range s {

--- a/internal/rpc/http_test.go
+++ b/internal/rpc/http_test.go
@@ -11,42 +11,36 @@ import (
 	"time"
 )
 
-// blockNumberServer returns an httptest.Server that answers eth_blockNumber
-// with hexBlocks[call], clamping to the last entry once exhausted.
-func blockNumberServer(hexBlocks ...string) *httptest.Server {
+// sequenceServer returns an httptest.Server that answers with results[call], clamping to
+// the last entry once exhausted.
+func sequenceServer(results ...any) *httptest.Server {
 	var calls atomic.Int64
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		idx := int(calls.Add(1) - 1)
-		if idx >= len(hexBlocks) {
-			idx = len(hexBlocks) - 1
-		}
+		idx := min(int(calls.Add(1)-1), len(results)-1)
 		w.Header().Set("Content-Type", "application/json")
 		json.NewEncoder(w).Encode(map[string]any{
 			"jsonrpc": "2.0",
 			"id":      1,
-			"result":  hexBlocks[idx],
+			"result":  results[idx],
 		})
 	}))
+}
+
+// blockNumberServer answers eth_blockNumber with the given block numbers, in order.
+func blockNumberServer(hexBlocks ...string) *httptest.Server {
+	results := make([]any, 0, len(hexBlocks))
+	for _, block := range hexBlocks {
+		results = append(results, block)
+	}
+	return sequenceServer(results...)
 }
 
 func targetOf(server *httptest.Server) string {
 	return strings.TrimPrefix(server.URL, "http://")
 }
 
-// jsonRPCServer returns an httptest.Server answering every request with result.
-func jsonRPCServer(result any) *httptest.Server {
-	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(map[string]any{
-			"jsonrpc": "2.0",
-			"id":      1,
-			"result":  result,
-		})
-	}))
-}
-
 func TestGetLatestHead(t *testing.T) {
-	server := jsonRPCServer(map[string]any{
+	server := sequenceServer(map[string]any{
 		"number": "0x1e8481",
 		"hash":   "0xabc",
 		// A real header carries many more fields: they must not disturb the read.
@@ -78,7 +72,7 @@ func TestGetLatestHead_Errors(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			server := jsonRPCServer(tc.result)
+			server := sequenceServer(tc.result)
 			defer server.Close()
 
 			if _, _, err := GetLatestHead(context.Background(), NewClient("http", "", 0), targetOf(server)); err == nil {

--- a/internal/rpc/http_test.go
+++ b/internal/rpc/http_test.go
@@ -1,6 +1,7 @@
 package rpc
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -13,9 +14,9 @@ import (
 // blockNumberServer returns an httptest.Server that answers eth_blockNumber
 // with hexBlocks[call], clamping to the last entry once exhausted.
 func blockNumberServer(hexBlocks ...string) *httptest.Server {
-	var calls int64
+	var calls atomic.Int64
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		idx := int(atomic.AddInt64(&calls, 1) - 1)
+		idx := int(calls.Add(1) - 1)
 		if idx >= len(hexBlocks) {
 			idx = len(hexBlocks) - 1
 		}
@@ -30,6 +31,61 @@ func blockNumberServer(hexBlocks ...string) *httptest.Server {
 
 func targetOf(server *httptest.Server) string {
 	return strings.TrimPrefix(server.URL, "http://")
+}
+
+// jsonRPCServer returns an httptest.Server answering every request with result.
+func jsonRPCServer(result any) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"jsonrpc": "2.0",
+			"id":      1,
+			"result":  result,
+		})
+	}))
+}
+
+func TestGetLatestHead(t *testing.T) {
+	server := jsonRPCServer(map[string]any{
+		"number": "0x1e8481",
+		"hash":   "0xabc",
+		// A real header carries many more fields: they must not disturb the read.
+		"parentHash": "0xdef",
+	})
+	defer server.Close()
+
+	head, _, err := GetLatestHead(context.Background(), NewClient("http", "", 0), targetOf(server))
+	if err != nil {
+		t.Fatalf("GetLatestHead: %v", err)
+	}
+	if head.Number != 0x1e8481 {
+		t.Errorf("head number: got %d, want %d", head.Number, uint64(0x1e8481))
+	}
+	if head.Hash != "0xabc" {
+		t.Errorf("head hash: got %q, want %q", head.Hash, "0xabc")
+	}
+}
+
+func TestGetLatestHead_Errors(t *testing.T) {
+	tests := []struct {
+		name   string
+		result any
+	}{
+		{"null result", nil},
+		{"missing number", map[string]any{"hash": "0xabc"}},
+		{"missing hash", map[string]any{"number": "0x1"}},
+		{"number not hex", map[string]any{"number": "0xzz", "hash": "0xabc"}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			server := jsonRPCServer(tc.result)
+			defer server.Close()
+
+			if _, _, err := GetLatestHead(context.Background(), NewClient("http", "", 0), targetOf(server)); err == nil {
+				t.Error("expected an error")
+			}
+		})
+	}
 }
 
 func TestGetConsistentLatestBlock_ImmediateMatch(t *testing.T) {

--- a/internal/runner/executor.go
+++ b/internal/runner/executor.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"os"
 	"path/filepath"
 	"sync"
 	"time"
@@ -49,87 +48,79 @@ func RunTest(ctx context.Context, descriptor *testdata.TestDescriptor, cfg *conf
 	// resolves the tag on its own, so a head moving under the test makes the two responses
 	// incomparable. Only relevant when there is a second node to compare against.
 	classifyHeads := descriptor.Latest && cfg.VerifyWithDaemon && !cfg.WithoutCompareResults && cfg.LatestRetries > 0
-	attempts := 1
-	if classifyHeads && cfg.LatestRetries > 1 {
-		attempts = cfg.LatestRetries
-	}
 
 	for attempt := 1; ; attempt++ {
-		var before headPair
+		var before, after headPair
+		var haveAfter bool
+		var notComparable func() bool
+
 		if classifyHeads {
-			before = readHeads(ctx, cfg, descriptor, client)
+			before = readHeads(ctx, cfg, client)
+			// The last attempt runs ungated, so a genuine failure still gets its full diff;
+			// the earlier ones are dropped as soon as the heads say they cannot be compared.
+			if attempt < cfg.LatestRetries {
+				notComparable = func() bool {
+					after, haveAfter = readHeads(ctx, cfg, client), true
+					return before.known() && after.known() && before != after
+				}
+			}
 		}
 
-		runCommands(ctx, cfg, commands, descriptor, &outcome, client)
+		runCommands(ctx, cfg, commands, descriptor, &outcome, client, notComparable)
 
-		if outcome.Success && outcome.Error == nil {
-			return outcome
-		}
-		if !classifyHeads || ctx.Err() != nil {
-			return outcome
-		}
-
-		after := readHeads(ctx, cfg, descriptor, client)
-		// Heads unreadable: nothing to classify with, take the failure at face value.
-		if !before.known() || !after.known() {
+		switch {
+		case outcome.Inconclusive:
+			// The nodes did not resolve "latest" to the same block: nothing was compared or
+			// written, only the two heads are logged, and the test is retried.
 			outcome.Notes = append(outcome.Notes, fmt.Sprintf(
-				"head unreadable, failure not classified (before: %s, after: %s)", before, after))
-			attachHeadEvidence(&outcome, before, after)
+				"inconclusive attempt %d/%d: head moved during test (%s -> %s), retrying",
+				attempt, cfg.LatestRetries, before, after))
+			continue
+		case outcome.Success && outcome.Error == nil:
 			return outcome
-		}
-		if before.equal(after) {
-			// Both nodes stayed on the same head for the whole test: the mismatch is real.
-			attachHeadEvidence(&outcome, before, after)
-			return outcome
-		}
-		if attempt >= attempts {
-			outcome.Notes = append(outcome.Notes, fmt.Sprintf(
-				"head moved on %d consecutive attempts, reported as failure (before: %s, after: %s)",
-				attempts, before, after))
-			attachHeadEvidence(&outcome, before, after)
+		case !classifyHeads || ctx.Err() != nil:
 			return outcome
 		}
 
-		// Inconclusive: the nodes did not resolve "latest" to the same block. Log only the
-		// head values (not the diff, which can be hundreds of MB) and retry.
-		outcome.Notes = append(outcome.Notes, fmt.Sprintf(
-			"inconclusive attempt %d/%d: head moved during test (before: %s, after: %s), retrying",
-			attempt, attempts, before, after))
-		discardAttempt(&outcome)
+		// The failure is final: judge it against the heads and attach them as evidence.
+		if !haveAfter {
+			after = readHeads(ctx, cfg, client)
+		}
+		switch {
+		case !before.known() || !after.known():
+			outcome.Notes = append(outcome.Notes, "head unreadable, failure not classified")
+		case before != after:
+			outcome.Notes = append(outcome.Notes, fmt.Sprintf(
+				"head moved during test on all %d attempts, reported as failure", attempt))
+		}
+		ensureErrorDetails(&outcome).Heads = &testdata.HeadEvidence{
+			Before: []testdata.HeadSnapshot{before.underTest, before.reference},
+			After:  []testdata.HeadSnapshot{after.underTest, after.reference},
+		}
+		return outcome
 	}
 }
 
 // runCommands executes the fixture's commands into outcome, resetting any verdict left by
 // a previous attempt. Multi-command fixtures run sequentially and stop at the first failing
 // command, so stateful sequences (e.g. commit then verify) stay ordered.
-func runCommands(ctx context.Context, cfg *config.Config, commands []testdata.JsonRpcCommand, descriptor *testdata.TestDescriptor, outcome *testdata.TestOutcome, client *internalrpc.Client) {
+func runCommands(ctx context.Context, cfg *config.Config, commands []testdata.JsonRpcCommand, descriptor *testdata.TestDescriptor, outcome *testdata.TestOutcome, client *internalrpc.Client, notComparable func() bool) {
 	outcome.Error = nil
 	outcome.ColoredDiff = ""
 	outcome.ErrorDetails = nil
-	outcome.Artifacts = nil
+	outcome.Inconclusive = false
 
 	for i := range commands {
 		outcome.Success = false
-		runCommand(ctx, cfg, &commands[i], descriptor, outcome, client)
+		runCommand(ctx, cfg, &commands[i], descriptor, outcome, client, notComparable)
 		if !outcome.Success || outcome.Error != nil {
 			return
 		}
 	}
 }
 
-// discardAttempt throws away the verdict and the artifacts of an inconclusive attempt.
-func discardAttempt(outcome *testdata.TestOutcome) {
-	for _, f := range outcome.Artifacts {
-		_ = os.Remove(f)
-	}
-	outcome.Artifacts = nil
-	outcome.Success = false
-	outcome.Error = nil
-	outcome.ColoredDiff = ""
-	outcome.ErrorDetails = nil
-}
-
-// headPair holds the head of the node under test and of the reference node.
+// headPair holds the head of the node under test and of the reference node. It is comparable,
+// so two pairs are compared with ==: on number and hash, which catches a tip reorg too.
 type headPair struct {
 	underTest testdata.HeadSnapshot
 	reference testdata.HeadSnapshot
@@ -139,20 +130,13 @@ func (p headPair) known() bool {
 	return p.underTest.Error == "" && p.reference.Error == ""
 }
 
-// equal reports whether both nodes are on the same head they were on in q.
-// The hash is compared as well as the number, so a tip reorg is caught too.
-func (p headPair) equal(q headPair) bool {
-	return p.underTest.Number == q.underTest.Number && p.underTest.Hash == q.underTest.Hash &&
-		p.reference.Number == q.reference.Number && p.reference.Hash == q.reference.Hash
-}
-
 func (p headPair) String() string {
-	return p.underTest.String() + " " + p.reference.String()
+	return formatHeads([]testdata.HeadSnapshot{p.underTest, p.reference})
 }
 
 // readHeads reads the current head of both nodes concurrently, so the two values refer to
 // as close to the same instant as possible.
-func readHeads(ctx context.Context, cfg *config.Config, descriptor *testdata.TestDescriptor, client *internalrpc.Client) headPair {
+func readHeads(ctx context.Context, cfg *config.Config, client *internalrpc.Client) headPair {
 	// Heads always come from the eth endpoint, even for engine_ tests.
 	underTest := cfg.GetTarget(config.DaemonOnDefaultPort, "eth_getBlockByNumber")
 	reference := cfg.GetTarget(cfg.DaemonAsReference, "eth_getBlockByNumber")
@@ -166,10 +150,6 @@ func readHeads(ctx context.Context, cfg *config.Config, descriptor *testdata.Tes
 	}()
 	pair.underTest = readHead(ctx, client, underTest)
 	wg.Wait()
-
-	if cfg.VerboseLevel > 1 {
-		fmt.Printf("%s: head %s\n", descriptor.Name, pair)
-	}
 	return pair
 }
 
@@ -184,33 +164,27 @@ func readHead(ctx context.Context, client *internalrpc.Client, target string) te
 	return snapshot
 }
 
-// attachHeadEvidence records the two heads on the failure details, as the evidence that
-// tells a real mismatch from one caused by the nodes tracing different blocks.
-func attachHeadEvidence(outcome *testdata.TestOutcome, before, after headPair) {
+// ensureErrorDetails returns the failure details of the outcome, creating them if the failure
+// carried none yet.
+func ensureErrorDetails(outcome *testdata.TestOutcome) *testdata.ErrorDetails {
 	if outcome.ErrorDetails == nil {
-		msg := ""
+		message := ""
 		if outcome.Error != nil {
-			msg = outcome.Error.Error()
+			message = outcome.Error.Error()
 		}
-		outcome.ErrorDetails = &testdata.ErrorDetails{Message: msg}
+		outcome.ErrorDetails = &testdata.ErrorDetails{Message: message}
 	}
-	outcome.ErrorDetails.Heads = &testdata.HeadEvidence{
-		Before: []testdata.HeadSnapshot{before.underTest, before.reference},
-		After:  []testdata.HeadSnapshot{after.underTest, after.reference},
-	}
+	return outcome.ErrorDetails
 }
 
 // enrichErrorDetails fills in Target and Request on an existing or newly created ErrorDetails.
 func enrichErrorDetails(outcome *testdata.TestOutcome, target string, request []byte) {
-	if outcome.ErrorDetails == nil {
-		if outcome.Error != nil {
-			outcome.ErrorDetails = &testdata.ErrorDetails{Message: outcome.Error.Error()}
-		} else {
-			return
-		}
+	if outcome.ErrorDetails == nil && outcome.Error == nil {
+		return
 	}
-	if outcome.ErrorDetails.Target == "" {
-		outcome.ErrorDetails.Target = target
+	details := ensureErrorDetails(outcome)
+	if details.Target == "" {
+		details.Target = target
 	}
 	if outcome.ErrorDetails.Request == nil && len(request) > 0 {
 		var req any
@@ -221,7 +195,7 @@ func enrichErrorDetails(outcome *testdata.TestOutcome, target string, request []
 }
 
 // runCommand executes a single JSON-RPC command against the target.
-func runCommand(ctx context.Context, cfg *config.Config, cmd *testdata.JsonRpcCommand, descriptor *testdata.TestDescriptor, outcome *testdata.TestOutcome, baseClient *internalrpc.Client) {
+func runCommand(ctx context.Context, cfg *config.Config, cmd *testdata.JsonRpcCommand, descriptor *testdata.TestDescriptor, outcome *testdata.TestOutcome, baseClient *internalrpc.Client, notComparable func() bool) {
 	transportType := descriptor.TransportType
 	jsonFile := descriptor.Name
 	request := cmd.Request
@@ -260,7 +234,7 @@ func runCommand(ctx context.Context, cfg *config.Config, cmd *testdata.JsonRpcCo
 			fmt.Printf("%s: [%v]\n", cfg.DaemonUnderTest, result)
 		}
 
-		compare.ProcessResponse(result, nil, cmd.Response, cfg, outputDirName, daemonFile, expRspFile, diffFile, outcome, ignoreFields)
+		compare.ProcessResponse(result, nil, cmd.Response, cfg, outputDirName, daemonFile, expRspFile, diffFile, outcome, ignoreFields, nil)
 		if !outcome.Success {
 			enrichErrorDetails(outcome, target, request)
 		}
@@ -304,8 +278,7 @@ func runCommand(ctx context.Context, cfg *config.Config, cmd *testdata.JsonRpcCo
 		daemonFile = outputAPIFilename + config.GetJSONFilenameExt(config.DaemonOnDefaultPort, target)
 		expRspFile = outputAPIFilename + config.GetJSONFilenameExt(cfg.DaemonAsReference, target1)
 
-		outcome.Artifacts = append(outcome.Artifacts, daemonFile, expRspFile, diffFile)
-		compare.ProcessResponse(result, result1, nil, cfg, outputDirName, daemonFile, expRspFile, diffFile, outcome, ignoreFields)
+		compare.ProcessResponse(result, result1, nil, cfg, outputDirName, daemonFile, expRspFile, diffFile, outcome, ignoreFields, notComparable)
 		if !outcome.Success {
 			enrichErrorDetails(outcome, target, request)
 		}

--- a/internal/runner/executor.go
+++ b/internal/runner/executor.go
@@ -6,7 +6,9 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"os"
 	"path/filepath"
+	"sync"
 	"time"
 
 	"github.com/golang-jwt/jwt/v5"
@@ -43,16 +45,159 @@ func RunTest(ctx context.Context, descriptor *testdata.TestDescriptor, cfg *conf
 		return outcome
 	}
 
-	// Multi-command fixtures run sequentially and stop at the first failing
-	// command, so stateful sequences (e.g. commit then verify) stay ordered.
-	for i := range commands {
-		outcome.Success = false
-		runCommand(ctx, cfg, &commands[i], descriptor, &outcome, client)
-		if !outcome.Success || outcome.Error != nil {
+	// A test on "latest" is classified on failure rather than failed outright: each node
+	// resolves the tag on its own, so a head moving under the test makes the two responses
+	// incomparable. Only relevant when there is a second node to compare against.
+	classifyHeads := descriptor.Latest && cfg.VerifyWithDaemon && !cfg.WithoutCompareResults && cfg.LatestRetries > 0
+	attempts := 1
+	if classifyHeads && cfg.LatestRetries > 1 {
+		attempts = cfg.LatestRetries
+	}
+
+	for attempt := 1; ; attempt++ {
+		var before headPair
+		if classifyHeads {
+			before = readHeads(ctx, cfg, descriptor, client)
+		}
+
+		runCommands(ctx, cfg, commands, descriptor, &outcome, client)
+
+		if outcome.Success && outcome.Error == nil {
 			return outcome
 		}
+		if !classifyHeads || ctx.Err() != nil {
+			return outcome
+		}
+
+		after := readHeads(ctx, cfg, descriptor, client)
+		// Heads unreadable: nothing to classify with, take the failure at face value.
+		if !before.known() || !after.known() {
+			outcome.Notes = append(outcome.Notes, fmt.Sprintf(
+				"head unreadable, failure not classified (before: %s, after: %s)", before, after))
+			attachHeadEvidence(&outcome, before, after)
+			return outcome
+		}
+		if before.equal(after) {
+			// Both nodes stayed on the same head for the whole test: the mismatch is real.
+			attachHeadEvidence(&outcome, before, after)
+			return outcome
+		}
+		if attempt >= attempts {
+			outcome.Notes = append(outcome.Notes, fmt.Sprintf(
+				"head moved on %d consecutive attempts, reported as failure (before: %s, after: %s)",
+				attempts, before, after))
+			attachHeadEvidence(&outcome, before, after)
+			return outcome
+		}
+
+		// Inconclusive: the nodes did not resolve "latest" to the same block. Log only the
+		// head values (not the diff, which can be hundreds of MB) and retry.
+		outcome.Notes = append(outcome.Notes, fmt.Sprintf(
+			"inconclusive attempt %d/%d: head moved during test (before: %s, after: %s), retrying",
+			attempt, attempts, before, after))
+		discardAttempt(&outcome)
 	}
-	return outcome
+}
+
+// runCommands executes the fixture's commands into outcome, resetting any verdict left by
+// a previous attempt. Multi-command fixtures run sequentially and stop at the first failing
+// command, so stateful sequences (e.g. commit then verify) stay ordered.
+func runCommands(ctx context.Context, cfg *config.Config, commands []testdata.JsonRpcCommand, descriptor *testdata.TestDescriptor, outcome *testdata.TestOutcome, client *internalrpc.Client) {
+	outcome.Error = nil
+	outcome.ColoredDiff = ""
+	outcome.ErrorDetails = nil
+	outcome.Artifacts = nil
+
+	for i := range commands {
+		outcome.Success = false
+		runCommand(ctx, cfg, &commands[i], descriptor, outcome, client)
+		if !outcome.Success || outcome.Error != nil {
+			return
+		}
+	}
+}
+
+// discardAttempt throws away the verdict and the artifacts of an inconclusive attempt.
+func discardAttempt(outcome *testdata.TestOutcome) {
+	for _, f := range outcome.Artifacts {
+		_ = os.Remove(f)
+	}
+	outcome.Artifacts = nil
+	outcome.Success = false
+	outcome.Error = nil
+	outcome.ColoredDiff = ""
+	outcome.ErrorDetails = nil
+}
+
+// headPair holds the head of the node under test and of the reference node.
+type headPair struct {
+	underTest testdata.HeadSnapshot
+	reference testdata.HeadSnapshot
+}
+
+func (p headPair) known() bool {
+	return p.underTest.Error == "" && p.reference.Error == ""
+}
+
+// equal reports whether both nodes are on the same head they were on in q.
+// The hash is compared as well as the number, so a tip reorg is caught too.
+func (p headPair) equal(q headPair) bool {
+	return p.underTest.Number == q.underTest.Number && p.underTest.Hash == q.underTest.Hash &&
+		p.reference.Number == q.reference.Number && p.reference.Hash == q.reference.Hash
+}
+
+func (p headPair) String() string {
+	return p.underTest.String() + " " + p.reference.String()
+}
+
+// readHeads reads the current head of both nodes concurrently, so the two values refer to
+// as close to the same instant as possible.
+func readHeads(ctx context.Context, cfg *config.Config, descriptor *testdata.TestDescriptor, client *internalrpc.Client) headPair {
+	// Heads always come from the eth endpoint, even for engine_ tests.
+	underTest := cfg.GetTarget(config.DaemonOnDefaultPort, "eth_getBlockByNumber")
+	reference := cfg.GetTarget(cfg.DaemonAsReference, "eth_getBlockByNumber")
+
+	var pair headPair
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		pair.reference = readHead(ctx, client, reference)
+	}()
+	pair.underTest = readHead(ctx, client, underTest)
+	wg.Wait()
+
+	if cfg.VerboseLevel > 1 {
+		fmt.Printf("%s: head %s\n", descriptor.Name, pair)
+	}
+	return pair
+}
+
+func readHead(ctx context.Context, client *internalrpc.Client, target string) testdata.HeadSnapshot {
+	snapshot := testdata.HeadSnapshot{Target: target}
+	head, _, err := internalrpc.GetLatestHead(ctx, client, target)
+	if err != nil {
+		snapshot.Error = err.Error()
+		return snapshot
+	}
+	snapshot.Number, snapshot.Hash = head.Number, head.Hash
+	return snapshot
+}
+
+// attachHeadEvidence records the two heads on the failure details, as the evidence that
+// tells a real mismatch from one caused by the nodes tracing different blocks.
+func attachHeadEvidence(outcome *testdata.TestOutcome, before, after headPair) {
+	if outcome.ErrorDetails == nil {
+		msg := ""
+		if outcome.Error != nil {
+			msg = outcome.Error.Error()
+		}
+		outcome.ErrorDetails = &testdata.ErrorDetails{Message: msg}
+	}
+	outcome.ErrorDetails.Heads = &testdata.HeadEvidence{
+		Before: []testdata.HeadSnapshot{before.underTest, before.reference},
+		After:  []testdata.HeadSnapshot{after.underTest, after.reference},
+	}
 }
 
 // enrichErrorDetails fills in Target and Request on an existing or newly created ErrorDetails.
@@ -121,37 +266,45 @@ func runCommand(ctx context.Context, cfg *config.Config, cmd *testdata.JsonRpcCo
 		}
 	} else {
 		target = cfg.GetTarget(config.DaemonOnDefaultPort, descriptor.Name)
+		target1 := cfg.GetTarget(cfg.DaemonAsReference, descriptor.Name)
 
-		var result any
-		metrics, err := client.Call(ctx, target, request, &result)
-		outcome.Metrics.RoundTripTime += metrics.RoundTripTime
-		outcome.Metrics.UnmarshallingTime += metrics.UnmarshallingTime
+		// Both requests are dispatched concurrently: a request resolving "latest" is resolved
+		// by each node when it arrives, so a sequential dispatch would let the head advance by
+		// the whole duration of the first response.
+		var result, result1 any
+		var metrics, metrics1 internalrpc.Metrics
+		var err, err1 error
+		var wg sync.WaitGroup
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			metrics1, err1 = client.Call(ctx, target1, request, &result1)
+		}()
+		metrics, err = client.Call(ctx, target, request, &result)
+		wg.Wait()
+
+		outcome.Metrics.RoundTripTime += metrics.RoundTripTime + metrics1.RoundTripTime
+		outcome.Metrics.UnmarshallingTime += metrics.UnmarshallingTime + metrics1.UnmarshallingTime
+
 		if err != nil {
 			outcome.Error = err
 			enrichErrorDetails(outcome, target, request)
 			return
 		}
-		if cfg.VerboseLevel > 2 {
-			fmt.Printf("%s: [%v]\n", cfg.DaemonUnderTest, result)
-		}
-
-		target1 := cfg.GetTarget(cfg.DaemonAsReference, descriptor.Name)
-		var result1 any
-		metrics1, err := client.Call(ctx, target1, request, &result1)
-		outcome.Metrics.RoundTripTime += metrics1.RoundTripTime
-		outcome.Metrics.UnmarshallingTime += metrics1.UnmarshallingTime
-		if err != nil {
-			outcome.Error = err
+		if err1 != nil {
+			outcome.Error = err1
 			enrichErrorDetails(outcome, target1, request)
 			return
 		}
 		if cfg.VerboseLevel > 2 {
+			fmt.Printf("%s: [%v]\n", cfg.DaemonUnderTest, result)
 			fmt.Printf("%s: [%v]\n", cfg.DaemonAsReference, result1)
 		}
 
 		daemonFile = outputAPIFilename + config.GetJSONFilenameExt(config.DaemonOnDefaultPort, target)
 		expRspFile = outputAPIFilename + config.GetJSONFilenameExt(cfg.DaemonAsReference, target1)
 
+		outcome.Artifacts = append(outcome.Artifacts, daemonFile, expRspFile, diffFile)
 		compare.ProcessResponse(result, result1, nil, cfg, outputDirName, daemonFile, expRspFile, diffFile, outcome, ignoreFields)
 		if !outcome.Success {
 			enrichErrorDetails(outcome, target, request)

--- a/internal/runner/executor_verify_test.go
+++ b/internal/runner/executor_verify_test.go
@@ -237,8 +237,12 @@ func TestRunTest_LatestHeadMovedRetriesThenFails(t *testing.T) {
 			t.Errorf("note %q should report an inconclusive attempt", note)
 		}
 	}
-	if !strings.Contains(outcome.Notes[2], "head moved on 3 consecutive attempts") {
+	if !strings.Contains(outcome.Notes[2], "head moved during test on all 3 attempts") {
 		t.Errorf("last note %q should report the exhausted retries", outcome.Notes[2])
+	}
+	// Only the last attempt is compared in full, so only its diff is on disk.
+	if files := resultFiles(t, cfg); len(files) != 3 {
+		t.Errorf("expected only the last attempt to leave response/diff files, found %v", files)
 	}
 	if outcome.ErrorDetails == nil || outcome.ErrorDetails.Heads == nil {
 		t.Errorf("the heads should be attached as evidence, got %+v", outcome.ErrorDetails)

--- a/internal/runner/executor_verify_test.go
+++ b/internal/runner/executor_verify_test.go
@@ -1,0 +1,336 @@
+package runner
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io/fs"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/erigontech/rpc-tests/internal/config"
+	internalrpc "github.com/erigontech/rpc-tests/internal/rpc"
+	"github.com/erigontech/rpc-tests/internal/testdata"
+)
+
+// fakeNode is a JSON-RPC server whose answers are sequenced per method: results[method][i]
+// answers the i-th call to that method, the last entry answering every call after it.
+type fakeNode struct {
+	server  *httptest.Server
+	mu      sync.Mutex
+	results map[string][]any
+	calls   map[string]int
+	before  func(method string) // hook invoked before answering, to synchronize with other nodes
+}
+
+func newFakeNode(t *testing.T, results map[string][]any) *fakeNode {
+	t.Helper()
+	node := &fakeNode{results: results, calls: map[string]int{}}
+	node.server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req struct {
+			Method string `json:"method"`
+			ID     any    `json:"id"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Errorf("fake node: cannot decode request: %v", err)
+			return
+		}
+
+		node.mu.Lock()
+		idx := node.calls[req.Method]
+		node.calls[req.Method]++
+		seq := node.results[req.Method]
+		before := node.before
+		node.mu.Unlock()
+
+		if before != nil {
+			before(req.Method)
+		}
+
+		var result any
+		if len(seq) > 0 {
+			result = seq[min(idx, len(seq)-1)]
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{"jsonrpc": "2.0", "id": req.ID, "result": result})
+	}))
+	t.Cleanup(node.server.Close)
+	return node
+}
+
+func (n *fakeNode) callCount(method string) int {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	return n.calls[method]
+}
+
+func (n *fakeNode) target() string {
+	return strings.TrimPrefix(n.server.URL, "http://")
+}
+
+// blockHead is one answer to eth_getBlockByNumber("latest", false).
+func blockHead(number, hash string) any {
+	return map[string]any{"number": number, "hash": hash}
+}
+
+// movingHeads returns a head sequence where every read sees a new block, i.e. a head that
+// never stands still between two reads.
+func movingHeads(count int) []any {
+	heads := make([]any, 0, count)
+	for i := range count {
+		heads = append(heads, blockHead(fmt.Sprintf("0x%x", 0x64+i), fmt.Sprintf("0xhash%d", i)))
+	}
+	return heads
+}
+
+// writeVerifyFixture builds a fixture and the config for verify-with-daemon mode, comparing
+// the node under test against a reference node (as with -e).
+func writeVerifyFixture(t *testing.T, underTest, reference *fakeNode, latest bool, commands []map[string]any) (*config.Config, *testdata.TestDescriptor) {
+	t.Helper()
+	cfg, descriptor := writeFixture(t, underTest.server, commands)
+	cfg.VerifyWithDaemon = true
+	cfg.DaemonAsReference = config.ExternalProvider
+	cfg.ExternalProviderURL = reference.target()
+	cfg.TestsOnLatestBlock = latest
+	descriptor.Latest = latest
+	return cfg, descriptor
+}
+
+// resultFiles lists the response/diff files left behind under the output directory.
+func resultFiles(t *testing.T, cfg *config.Config) []string {
+	t.Helper()
+	var files []string
+	err := filepath.WalkDir(cfg.OutputDir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if !d.IsDir() {
+			files = append(files, path)
+		}
+		return nil
+	})
+	if err != nil && !os.IsNotExist(err) {
+		t.Fatalf("walking %s: %v", cfg.OutputDir, err)
+	}
+	return files
+}
+
+// The two nodes resolve the "latest" tag when the request arrives, so both requests must be
+// in flight at the same time: the reference node must be called before the node under test
+// has answered.
+func TestRunTest_DispatchesBothNodesConcurrently(t *testing.T) {
+	referenceCalled := make(chan struct{})
+	var notConcurrent atomic.Bool
+
+	underTest := newFakeNode(t, map[string][]any{"m1": {"r1"}})
+	reference := newFakeNode(t, map[string][]any{"m1": {"r1"}})
+
+	reference.before = func(method string) {
+		if method == "m1" {
+			close(referenceCalled)
+		}
+	}
+	underTest.before = func(method string) {
+		if method != "m1" {
+			return
+		}
+		select {
+		case <-referenceCalled:
+		case <-time.After(10 * time.Second):
+			notConcurrent.Store(true)
+		}
+	}
+
+	cfg, descriptor := writeVerifyFixture(t, underTest, reference, false, []map[string]any{command("m1", "r1")})
+	outcome := RunTest(context.Background(), descriptor, cfg, internalrpc.NewClient("http", "", 0))
+
+	if notConcurrent.Load() {
+		t.Fatal("the reference node was called only after the node under test answered: the two requests are not dispatched concurrently")
+	}
+	if outcome.Error != nil {
+		t.Fatalf("RunTest error: %v", outcome.Error)
+	}
+	if !outcome.Success {
+		t.Error("expected success when both nodes answer the same result")
+	}
+}
+
+// Both nodes report an error: the one from the node under test is the one reported.
+func TestRunTest_ReferenceErrorReported(t *testing.T) {
+	underTest := newFakeNode(t, map[string][]any{"m1": {"r1"}})
+	reference := newFakeNode(t, map[string][]any{"m1": {"r1"}})
+	reference.server.Close() // the reference node is unreachable
+
+	cfg, descriptor := writeVerifyFixture(t, underTest, reference, false, []map[string]any{command("m1", "r1")})
+	outcome := RunTest(context.Background(), descriptor, cfg, internalrpc.NewClient("http", "", 0))
+
+	if outcome.Error == nil {
+		t.Fatal("expected an error when the reference node is unreachable")
+	}
+	if outcome.ErrorDetails == nil || outcome.ErrorDetails.Target != reference.target() {
+		t.Errorf("error details should point at the reference node %s, got %+v", reference.target(), outcome.ErrorDetails)
+	}
+}
+
+// Heads stable on both nodes: the mismatch is real, reported at the first attempt.
+func TestRunTest_LatestStableHeadFailsWithoutRetry(t *testing.T) {
+	stable := []any{blockHead("0x64", "0xaa")}
+	underTest := newFakeNode(t, map[string][]any{"m1": {"r1"}, "eth_getBlockByNumber": stable})
+	reference := newFakeNode(t, map[string][]any{"m1": {"r2"}, "eth_getBlockByNumber": stable})
+
+	cfg, descriptor := writeVerifyFixture(t, underTest, reference, true, []map[string]any{command("m1", "r1")})
+	outcome := RunTest(context.Background(), descriptor, cfg, internalrpc.NewClient("http", "", 0))
+
+	if outcome.Success {
+		t.Fatal("expected failure: the two nodes answered different results on the same head")
+	}
+	if got := underTest.callCount("m1"); got != 1 {
+		t.Errorf("attempts: got %d, want 1 (a stable head means the mismatch is real)", got)
+	}
+	if len(outcome.Notes) != 0 {
+		t.Errorf("no inconclusive note expected, got %v", outcome.Notes)
+	}
+	if outcome.ErrorDetails == nil || outcome.ErrorDetails.Heads == nil {
+		t.Fatalf("the heads should be attached as evidence, got %+v", outcome.ErrorDetails)
+	}
+	heads := outcome.ErrorDetails.Heads
+	if len(heads.Before) != 2 || len(heads.After) != 2 {
+		t.Fatalf("expected the head of both nodes before and after, got %+v", heads)
+	}
+	if heads.Before[0].Number != 0x64 || heads.Before[0].Hash != "0xaa" {
+		t.Errorf("head of the node under test: got %+v", heads.Before[0])
+	}
+	// The diff of a real failure is kept as evidence.
+	if len(resultFiles(t, cfg)) == 0 {
+		t.Error("expected the response/diff files of a real failure to be kept")
+	}
+}
+
+// The head moves under every attempt: the result stays inconclusive and is reported as a
+// failure only after the retries are exhausted, with the heads as evidence.
+func TestRunTest_LatestHeadMovedRetriesThenFails(t *testing.T) {
+	underTest := newFakeNode(t, map[string][]any{"m1": {"r1"}, "eth_getBlockByNumber": movingHeads(8)})
+	reference := newFakeNode(t, map[string][]any{"m1": {"r2"}, "eth_getBlockByNumber": {blockHead("0x64", "0xaa")}})
+
+	cfg, descriptor := writeVerifyFixture(t, underTest, reference, true, []map[string]any{command("m1", "r1")})
+	cfg.LatestRetries = 3
+	outcome := RunTest(context.Background(), descriptor, cfg, internalrpc.NewClient("http", "", 0))
+
+	if outcome.Success {
+		t.Fatal("expected failure after the retries are exhausted")
+	}
+	if got := underTest.callCount("m1"); got != 3 {
+		t.Errorf("attempts: got %d, want 3 (--latest-retries)", got)
+	}
+	if len(outcome.Notes) != 3 {
+		t.Fatalf("expected 2 inconclusive notes plus the final one, got %v", outcome.Notes)
+	}
+	for _, note := range outcome.Notes[:2] {
+		if !strings.Contains(note, "inconclusive") {
+			t.Errorf("note %q should report an inconclusive attempt", note)
+		}
+	}
+	if !strings.Contains(outcome.Notes[2], "head moved on 3 consecutive attempts") {
+		t.Errorf("last note %q should report the exhausted retries", outcome.Notes[2])
+	}
+	if outcome.ErrorDetails == nil || outcome.ErrorDetails.Heads == nil {
+		t.Errorf("the heads should be attached as evidence, got %+v", outcome.ErrorDetails)
+	}
+}
+
+// The head moved during the first attempt but the retry runs within one block: the test
+// passes, and the artifacts of the discarded attempt are not left behind.
+func TestRunTest_LatestInconclusiveThenPasses(t *testing.T) {
+	underTest := newFakeNode(t, map[string][]any{
+		"m1":                   {"stale", "r1"},
+		"eth_getBlockByNumber": {blockHead("0x64", "0xaa"), blockHead("0x65", "0xbb"), blockHead("0x65", "0xbb")},
+	})
+	reference := newFakeNode(t, map[string][]any{
+		"m1":                   {"r1"},
+		"eth_getBlockByNumber": {blockHead("0x65", "0xbb")},
+	})
+
+	cfg, descriptor := writeVerifyFixture(t, underTest, reference, true, []map[string]any{command("m1", "r1")})
+	outcome := RunTest(context.Background(), descriptor, cfg, internalrpc.NewClient("http", "", 0))
+
+	if outcome.Error != nil || !outcome.Success {
+		t.Fatalf("expected success on the retry, got success=%v error=%v", outcome.Success, outcome.Error)
+	}
+	if got := underTest.callCount("m1"); got != 2 {
+		t.Errorf("attempts: got %d, want 2 (one inconclusive, one good)", got)
+	}
+	if len(outcome.Notes) != 1 || !strings.Contains(outcome.Notes[0], "inconclusive") {
+		t.Errorf("expected one inconclusive note, got %v", outcome.Notes)
+	}
+	if files := resultFiles(t, cfg); len(files) != 0 {
+		t.Errorf("the artifacts of the discarded attempt should have been removed, found %v", files)
+	}
+}
+
+// With --latest-retries 0 the head is not read at all and the failure is reported as is.
+func TestRunTest_LatestClassificationDisabled(t *testing.T) {
+	underTest := newFakeNode(t, map[string][]any{"m1": {"r1"}, "eth_getBlockByNumber": movingHeads(4)})
+	reference := newFakeNode(t, map[string][]any{"m1": {"r2"}, "eth_getBlockByNumber": movingHeads(4)})
+
+	cfg, descriptor := writeVerifyFixture(t, underTest, reference, true, []map[string]any{command("m1", "r1")})
+	cfg.LatestRetries = 0
+	outcome := RunTest(context.Background(), descriptor, cfg, internalrpc.NewClient("http", "", 0))
+
+	if outcome.Success {
+		t.Fatal("expected failure")
+	}
+	if got := underTest.callCount("eth_getBlockByNumber"); got != 0 {
+		t.Errorf("no head read expected with --latest-retries 0, got %d", got)
+	}
+	if got := underTest.callCount("m1"); got != 1 {
+		t.Errorf("attempts: got %d, want 1", got)
+	}
+	if outcome.ErrorDetails != nil && outcome.ErrorDetails.Heads != nil {
+		t.Error("no head evidence expected when the check is disabled")
+	}
+}
+
+// A non-latest test is never re-run, even if the nodes are moving.
+func TestRunTest_NonLatestNotRetried(t *testing.T) {
+	underTest := newFakeNode(t, map[string][]any{"m1": {"r1"}})
+	reference := newFakeNode(t, map[string][]any{"m1": {"r2"}})
+
+	cfg, descriptor := writeVerifyFixture(t, underTest, reference, false, []map[string]any{command("m1", "r1")})
+	outcome := RunTest(context.Background(), descriptor, cfg, internalrpc.NewClient("http", "", 0))
+
+	if outcome.Success {
+		t.Fatal("expected failure")
+	}
+	if got := underTest.callCount("eth_getBlockByNumber"); got != 0 {
+		t.Errorf("no head read expected for a test that does not use the latest tag, got %d", got)
+	}
+	if got := underTest.callCount("m1"); got != 1 {
+		t.Errorf("attempts: got %d, want 1", got)
+	}
+}
+
+// When a head cannot be read the failure is reported as is, with the reason logged.
+func TestRunTest_LatestHeadUnreadable(t *testing.T) {
+	underTest := newFakeNode(t, map[string][]any{"m1": {"r1"}}) // no head answer: null result
+	reference := newFakeNode(t, map[string][]any{"m1": {"r2"}, "eth_getBlockByNumber": {blockHead("0x64", "0xaa")}})
+
+	cfg, descriptor := writeVerifyFixture(t, underTest, reference, true, []map[string]any{command("m1", "r1")})
+	outcome := RunTest(context.Background(), descriptor, cfg, internalrpc.NewClient("http", "", 0))
+
+	if outcome.Success {
+		t.Fatal("expected failure")
+	}
+	if got := underTest.callCount("m1"); got != 1 {
+		t.Errorf("attempts: got %d, want 1 (an unclassifiable failure is not retried)", got)
+	}
+	if len(outcome.Notes) != 1 || !strings.Contains(outcome.Notes[0], "head unreadable") {
+		t.Errorf("expected a note about the unreadable head, got %v", outcome.Notes)
+	}
+}

--- a/internal/runner/report.go
+++ b/internal/runner/report.go
@@ -15,11 +15,12 @@ import (
 
 // reportEntry mirrors the Python test_results list entry.
 type reportEntry struct {
-	TestNumber    int    `json:"test_number"`
-	TransportType string `json:"transport_type"`
-	TestName      string `json:"test_name"`
-	Result        string `json:"result"`
-	ErrorMessage  any    `json:"error_message"`
+	TestNumber    int      `json:"test_number"`
+	TransportType string   `json:"transport_type"`
+	TestName      string   `json:"test_name"`
+	Result        string   `json:"result"`
+	ErrorMessage  any      `json:"error_message"`
+	Notes         []string `json:"notes,omitempty"`
 }
 
 type reportSummary struct {

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -274,6 +274,7 @@ outer:
 						Name:          jsonTestFullName,
 						Number:        testNumberInAnyLoop,
 						TransportType: transportType,
+						Latest:        tc.Latest,
 					})
 					stats.ScheduledTests++
 				}
@@ -382,6 +383,21 @@ schedLoop:
 	fmt.Fprintln(w)
 }
 
+// printNotes prints the diagnostic lines a test attached to its outcome, indented under it.
+func printNotes(w *bufio.Writer, notes []string) {
+	for _, note := range notes {
+		fmt.Fprintf(w, "      %s\n", note)
+	}
+}
+
+func formatHeads(heads []testdata.HeadSnapshot) string {
+	parts := make([]string, 0, len(heads))
+	for _, h := range heads {
+		parts = append(parts, h.String())
+	}
+	return strings.Join(parts, " ")
+}
+
 func printResult(w *bufio.Writer, result *testdata.TestResult, stats *Stats, cfg *config.Config, cancelCtx context.CancelFunc, reportEntries *[]reportEntry, reportMu *sync.Mutex) {
 	file := fmt.Sprintf("%-60s", result.Test.Name)
 	tt := fmt.Sprintf("%-15s", result.Test.TransportType)
@@ -389,11 +405,12 @@ func printResult(w *bufio.Writer, result *testdata.TestResult, stats *Stats, cfg
 
 	if result.Outcome.Success {
 		stats.AddSuccess(result.Outcome.Metrics)
-		if cfg.VerboseLevel > 0 {
+		if cfg.VerboseLevel > 0 || len(result.Outcome.Notes) > 0 {
 			fmt.Fprintln(w, "OK")
 		} else {
 			fmt.Fprint(w, "OK\r")
 		}
+		printNotes(w, result.Outcome.Notes)
 		if cfg.VerboseLevel == 1 || cfg.ReportFile != "" {
 			reportMu.Lock()
 			*reportEntries = append(*reportEntries, reportEntry{
@@ -402,6 +419,7 @@ func printResult(w *bufio.Writer, result *testdata.TestResult, stats *Stats, cfg
 				TestName:      result.Test.Name,
 				Result:        "OK",
 				ErrorMessage:  "",
+				Notes:         result.Outcome.Notes,
 			})
 			reportMu.Unlock()
 		}
@@ -410,12 +428,16 @@ func printResult(w *bufio.Writer, result *testdata.TestResult, stats *Stats, cfg
 		errMsg := "no error"
 		if result.Outcome.Error != nil {
 			errMsg = result.Outcome.Error.Error()
-			fmt.Fprintf(w, "failed: %s\n", errMsg)
-			if errors.Is(result.Outcome.Error, compare.ErrDiffMismatch) && result.Outcome.ColoredDiff != "" {
-				fmt.Fprint(w, result.Outcome.ColoredDiff)
-			}
-		} else {
-			fmt.Fprintf(w, "failed: %s\n", errMsg)
+		}
+		fmt.Fprintf(w, "failed: %s\n", errMsg)
+		printNotes(w, result.Outcome.Notes)
+		if result.Outcome.ErrorDetails != nil && result.Outcome.ErrorDetails.Heads != nil {
+			heads := result.Outcome.ErrorDetails.Heads
+			fmt.Fprintf(w, "      heads before: %s\n", formatHeads(heads.Before))
+			fmt.Fprintf(w, "      heads after:  %s\n", formatHeads(heads.After))
+		}
+		if result.Outcome.Error != nil && errors.Is(result.Outcome.Error, compare.ErrDiffMismatch) && result.Outcome.ColoredDiff != "" {
+			fmt.Fprint(w, result.Outcome.ColoredDiff)
 		}
 		if cfg.VerboseLevel == 1 || cfg.ReportFile != "" {
 			var errField any = errMsg
@@ -429,6 +451,7 @@ func printResult(w *bufio.Writer, result *testdata.TestResult, stats *Stats, cfg
 				TestName:      result.Test.Name,
 				Result:        "FAILED",
 				ErrorMessage:  errField,
+				Notes:         result.Outcome.Notes,
 			})
 			reportMu.Unlock()
 		}

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -226,6 +226,70 @@ func TestMaxFailures_ZeroMeansUnlimited(t *testing.T) {
 	}
 }
 
+// A latest-block failure prints the notes of the discarded attempts and the two heads, and
+// carries both into the report entry.
+func TestPrintResult_LatestHeadEvidence(t *testing.T) {
+	cfg := config.NewConfig()
+	cfg.ExitOnFail = false
+	cfg.VerboseLevel = 1
+
+	var buf bytes.Buffer
+	w := bufio.NewWriter(&buf)
+	stats := &Stats{}
+	var entries []reportEntry
+	var mu sync.Mutex
+
+	r := testdata.TestResult{
+		Outcome: testdata.TestOutcome{
+			Success: false,
+			Error:   fmt.Errorf("json diff mismatch"),
+			Notes:   []string{"inconclusive attempt 1/3: head moved during test, retrying"},
+			ErrorDetails: &testdata.ErrorDetails{
+				Message: "json diff mismatch",
+				Heads: &testdata.HeadEvidence{
+					Before: []testdata.HeadSnapshot{
+						{Target: "localhost:8545", Number: 100, Hash: "0xaa"},
+						{Target: "localhost:8546", Number: 100, Hash: "0xaa"},
+					},
+					After: []testdata.HeadSnapshot{
+						{Target: "localhost:8545", Number: 101, Hash: "0xbb"},
+						{Target: "localhost:8546", Number: 100, Hash: "0xaa"},
+					},
+				},
+			},
+		},
+		Test: &testdata.TestDescriptor{
+			Name:          "debug_traceBlockByNumber/test_24.json",
+			Number:        246,
+			TransportType: "http",
+			Latest:        true,
+		},
+	}
+	printResult(w, &r, stats, cfg, func() {}, &entries, &mu)
+	w.Flush()
+
+	output := buf.String()
+	for _, want := range []string{
+		"inconclusive attempt 1/3",
+		"heads before: localhost:8545=100/0xaa localhost:8546=100/0xaa",
+		"heads after:  localhost:8545=101/0xbb localhost:8546=100/0xaa",
+	} {
+		if !strings.Contains(output, want) {
+			t.Errorf("expected %q in output, got:\n%s", want, output)
+		}
+	}
+	if len(entries) != 1 {
+		t.Fatalf("report entries: got %d, want 1", len(entries))
+	}
+	if len(entries[0].Notes) != 1 {
+		t.Errorf("the report entry should carry the notes, got %+v", entries[0].Notes)
+	}
+	details, ok := entries[0].ErrorMessage.(*testdata.ErrorDetails)
+	if !ok || details.Heads == nil {
+		t.Errorf("the report entry should carry the head evidence, got %+v", entries[0].ErrorMessage)
+	}
+}
+
 func TestPrintResult_OrderedOutput(t *testing.T) {
 	const numTests = 50
 

--- a/internal/testdata/types.go
+++ b/internal/testdata/types.go
@@ -76,9 +76,9 @@ type TestOutcome struct {
 	// Notes carries short diagnostic lines printed next to the test result,
 	// e.g. inconclusive attempts discarded because the nodes' heads moved.
 	Notes []string
-	// Artifacts lists the response/diff files the last attempt may have written,
-	// so a discarded attempt can clean up after itself.
-	Artifacts []string
+	// Inconclusive reports that the two responses turned out not to be comparable, so the
+	// attempt says nothing about the node under test and can be retried.
+	Inconclusive bool
 }
 
 // TestMetrics tracks timing and comparison statistics for a single test.

--- a/internal/testdata/types.go
+++ b/internal/testdata/types.go
@@ -1,6 +1,7 @@
 package testdata
 
 import (
+	"fmt"
 	"time"
 
 	jsoniter "github.com/json-iterator/go"
@@ -21,7 +22,8 @@ type TestDescriptor struct {
 	Name          string
 	Number        int
 	TransportType string
-	Index         int // Position in scheduled order (for ordered output)
+	Index         int  // Position in scheduled order (for ordered output)
+	Latest        bool // metadata.latest: the request resolves the "latest" tag on the node
 }
 
 // TestResult holds a test outcome and its descriptor.
@@ -30,14 +32,38 @@ type TestResult struct {
 	Test    *TestDescriptor
 }
 
+// HeadSnapshot records the head a node was on, as read from that node.
+type HeadSnapshot struct {
+	Target string `json:"target"`
+	Number uint64 `json:"number,omitempty"`
+	Hash   string `json:"hash,omitempty"`
+	Error  string `json:"error,omitempty"`
+}
+
+// String renders the snapshot compactly for log lines.
+func (h HeadSnapshot) String() string {
+	if h.Error != "" {
+		return h.Target + "=<" + h.Error + ">"
+	}
+	return fmt.Sprintf("%s=%d/%s", h.Target, h.Number, h.Hash)
+}
+
+// HeadEvidence holds the heads of both nodes read before and after a latest-block test,
+// so a failure can be judged against the head each node actually resolved "latest" to.
+type HeadEvidence struct {
+	Before []HeadSnapshot `json:"before,omitempty"`
+	After  []HeadSnapshot `json:"after,omitempty"`
+}
+
 // ErrorDetails holds structured failure information for the JSON report.
 type ErrorDetails struct {
-	Message          string `json:"message,omitempty"`
-	Target           string `json:"target,omitempty"`
-	ActualResponse   any    `json:"actual_response,omitempty"`
-	ExpectedResponse any    `json:"expected_response,omitempty"`
-	Diff             string `json:"diff,omitempty"`
-	Request          any    `json:"request,omitempty"`
+	Message          string        `json:"message,omitempty"`
+	Target           string        `json:"target,omitempty"`
+	ActualResponse   any           `json:"actual_response,omitempty"`
+	ExpectedResponse any           `json:"expected_response,omitempty"`
+	Diff             string        `json:"diff,omitempty"`
+	Request          any           `json:"request,omitempty"`
+	Heads            *HeadEvidence `json:"heads,omitempty"`
 }
 
 // TestOutcome holds the result of executing a single test.
@@ -47,6 +73,12 @@ type TestOutcome struct {
 	ColoredDiff  string
 	Metrics      TestMetrics
 	ErrorDetails *ErrorDetails
+	// Notes carries short diagnostic lines printed next to the test result,
+	// e.g. inconclusive attempts discarded because the nodes' heads moved.
+	Notes []string
+	// Artifacts lists the response/diff files the last attempt may have written,
+	// so a discarded attempt can clean up after itself.
+	Artifacts []string
 }
 
 // TestMetrics tracks timing and comparison statistics for a single test.


### PR DESCRIPTION
Addresses points **a)** and **b)** of the analysis of the intermittent failure of `debug_traceBlockByNumber/test_24.json`
(run [30738069136](https://github.com/erigontech/erigon/actions/runs/30738069136): attempt 1 failed, attempt 2 passed).

### Cause

The test sends the literal tag `"latest"`, resolved independently by each node when the request arrives. The two calls
were sequential in `internal/runner/executor.go`, so the gap between the two resolutions equalled the duration of the
first call — seconds, for a 182 MB response, against a 12-second slot. The two nodes traced different blocks (Erigon 537
traces, Geth 354) and the diff was 130 MB of noise. The per-batch gate does not help: it checks that both nodes agree
*before* the batch but never pins the block.

### a) Concurrent dispatch

In verify-with-daemon mode (`-e` / `-d`) the two requests are now dispatched concurrently. Each node resolves `latest`
when the request arrives, so the duration of the test stops mattering; what is left is only the sub-second skew between
the nodes in updating their own head. It also roughly halves the suite wall time in this mode.

Note: both nodes now serve the request at the same time, so the instantaneous load/memory peak on the machine running
them doubles for the heavy tracing tests.

### b) Classify on failure instead of gating on the head

The head (number **and hash**, so a tip reorg is caught too) is read on both nodes before a `latest` test and, **only if
the test fails**, read again:

- heads stable on both sides → the mismatch is real, reported immediately (heads attached as evidence);
- a head moved → the two sides did not resolve the same block: the attempt is **inconclusive**, the test is retried in
  process, and the response/diff files of the discarded attempt are removed. Only the two head values are logged, to
  keep the artifacts small;
- retries exhausted (`--latest-retries`, default 3) → reported as a real failure, with both heads attached in the
  console output and in the JSON report (`error_message.heads.before/after`, plus a `notes` field on the entry);
- head unreadable → failure taken at face value, with the reason logged.

The retry is inside `rpc_int`, per test, so an inconclusive result never reaches the outer loop of
`run_rpc_tests.sh`, which would waste a full suite run plus ~450 MB of artifacts for a test that did not really fail
(and three consecutive skews would turn the job red for nothing).

Example output:

```
0246. http           ::debug_traceBlockByNumber/test_24.json   failed: json diff mismatch
      inconclusive attempt 1/3: head moved during test (before: ... after: ...), retrying
```

New flag: `--latest-retries <n>` (default 3; `1` = classify without retrying, `0` = disable the head check).

### Tests

- `internal/rpc`: `GetLatestHead` happy path and error cases (null result, missing `number`/`hash`, non-hex number).
- `internal/runner/executor_verify_test.go`: a fake node whose answers are sequenced per method, so the head can be made
  to move between two reads. Covers concurrent dispatch (the node under test does not answer until the reference has
  received the same request — verified that the test fails if the dispatch is made sequential again), reference-node
  error reporting, stable head → immediate failure with evidence and diff kept, moving head → 3 attempts then failure,
  inconclusive-then-passes → success with no leftover artifacts, `--latest-retries 0`, non-latest tests, unreadable head.
- `internal/runner`: `printResult` prints the notes and the two heads and carries both into the report entry.

`go test -race ./...` and `golangci-lint run` are clean.

Point **c)** of the analysis (opt-in `pinLatest` in the test metadata) is intentionally **not** implemented: it should
only be considered if a) and b) turn out not to be enough, since pinning a block number no longer exercises the
uncommitted-block-overlay read path that `latest` always hits.

<sub>The `atomic.Int64` cleanup in `internal/rpc/http_test.go` was already in the working tree and is unrelated.</sub>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
