### PR TITLE
integration_test: debug_traceBlockByNumber(pending) now returns an error

### DIFF
--- a/integration/mainnet/debug_traceBlockByNumber/test_25.json
+++ b/integration/mainnet/debug_traceBlockByNumber/test_25.json
@@ -16,10 +16,14 @@
     "response": {
       "id": 1,
       "jsonrpc": "2.0",
-      "result": null
+      "result": null,
+      "error": {
+        "code": -32000,
+        "message": "tracing on top of pending is not supported"
+      }
     },
     "test": {
-      "description": "trace the pending block",
+      "description": "trace the pending block: rejected, tracing replays committed state",
       "reference": ""
     }
   }


### PR DESCRIPTION
Erigon is changing the tracing methods to reject the `pending` block tag instead of silently answering for a different block.

Those methods resolve and replay on the committed view, which holds no pending block. Today `pending` falls through to the latest executed block, so `debug_traceBlockByNumber("pending")` returns a full trace of the head block while the caller asked for pending. go-ethereum either traces a real pending block or errors — it never substitutes another one.

This updates the one fixture that pins the old behaviour. Paired with erigontech/erigon#22533, which needs a release of this repo and an `RPC_VERSION` bump before its CI goes green.

## Changes

- `debug_traceBlockByNumber/test_25.json` — expect `-32000 "tracing on top of pending is not supported"` instead of `result: null`.