### PR TITLE
integration_test: remove result from pending trace error

### DIFF
--- a/integration/mainnet/debug_traceBlockByNumber/test_25.json
+++ b/integration/mainnet/debug_traceBlockByNumber/test_25.json
@@ -16,7 +16,6 @@
     "response": {
       "id": 1,
       "jsonrpc": "2.0",
-      "result": null,
       "error": {
         "code": -32000,
         "message": "tracing on top of pending is not supported"


### PR DESCRIPTION
PR #588 added the expected JSON-RPC error but left the old `result: null` member in the same response. Erigon correctly returns only the error, so erigontech/erigon#22533 still fails on all three transports with `- result: null`.

This removes the stale result member. The corrected fixture exactly matches the response captured in https://github.com/erigontech/erigon/actions/runs/32238375580/job/96023310119.

## Validation

- `jq empty integration/mainnet/debug_traceBlockByNumber/test_25.json`
- `make test`
- `make lint`