### PR TITLE
erigon_getLogsByHash: expect [] instead of null for receipts with no logs

### DIFF
--- a/integration/mainnet/erigon_getLogsByHash/test_01.json
+++ b/integration/mainnet/erigon_getLogsByHash/test_01.json
@@ -10,9 +10,9 @@
            "id": 1,
            "jsonrpc": "2.0",
            "result": [
-                null,
-                null,
-                null
+                [],
+                [],
+                []
            ]
         }
     }

--- a/integration/mainnet/erigon_getLogsByHash/test_02.json
+++ b/integration/mainnet/erigon_getLogsByHash/test_02.json
@@ -792,8 +792,8 @@
         "transactionIndex": "0x1"
       }
     ],
-    null,
-    null,
+    [],
+    [],
     [
       {
         "address": "0xdac17f958d2ee523a2206206994597c13d831ec7",
@@ -811,7 +811,7 @@
         "transactionIndex": "0x4"
       }
     ],
-    null,
+    [],
     [
       {
         "address": "0xcdf7028ceab81fa0c6971208e83fa7872994bee5",
@@ -829,8 +829,8 @@
         "transactionIndex": "0x6"
       }
     ],
-    null,
-    null,
+    [],
+    [],
     [
       {
         "address": "0x0a82fc64ecfd6669899857ae3bb4c85398721fdd",
@@ -952,7 +952,7 @@
         "transactionIndex": "0xa"
       }
     ],
-    null,
+    [],
     [
       {
         "address": "0x0c3d8b3ba891310107f1d2ff99f406ed27599151",
@@ -1269,7 +1269,7 @@
         "transactionIndex": "0xf"
       }
     ],
-    null,
+    [],
     [
       {
         "address": "0x2f8221e82e0d4669ad66eabf02a5baed43ea49e7",
@@ -1541,7 +1541,7 @@
         "transactionIndex": "0x13"
       }
     ],
-    null,
+    [],
     [
       {
         "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -1603,7 +1603,7 @@
         "transactionIndex": "0x15"
       }
     ],
-    null,
+    [],
     [
       {
         "address": "0x000000000022d473030f116ddee9f6b43ac78ba3",
@@ -2024,7 +2024,7 @@
         "transactionIndex": "0x1a"
       }
     ],
-    null,
+    [],
     [
       {
         "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -2678,7 +2678,7 @@
         "transactionIndex": "0x2a"
       }
     ],
-    null,
+    [],
     [
       {
         "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -2883,7 +2883,7 @@
         "transactionIndex": "0x32"
       }
     ],
-    null,
+    [],
     [
       {
         "address": "0x8f7a443d9c4920a21032069d2545b55ccfb75737",
@@ -2986,7 +2986,7 @@
         "transactionIndex": "0x39"
       }
     ],
-    null,
+    [],
     [
       {
         "address": "0x43d7e65b8ff49698d9550a7f315c87e67344fb59",
@@ -3038,7 +3038,7 @@
         "transactionIndex": "0x3d"
       }
     ],
-    null,
+    [],
     [
       {
         "address": "0xf6afc05fccea5a53f22a3e39ffee861e016bd9a0",
@@ -3056,7 +3056,7 @@
         "transactionIndex": "0x3f"
       }
     ],
-    null,
+    [],
     [
       {
         "address": "0xdac17f958d2ee523a2206206994597c13d831ec7",
@@ -3074,17 +3074,17 @@
         "transactionIndex": "0x41"
       }
     ],
-    null,
-    null,
-    null,
-    null,
-    null,
-    null,
-    null,
-    null,
-    null,
-    null,
-    null,
+    [],
+    [],
+    [],
+    [],
+    [],
+    [],
+    [],
+    [],
+    [],
+    [],
+    [],
     [
       {
         "address": "0x5f65f7b609678448494de4c87521cdf6cef1e932",
@@ -4424,7 +4424,7 @@
         "transactionIndex": "0x59"
       }
     ],
-    null,
+    [],
     [
       {
         "address": "0xdac17f958d2ee523a2206206994597c13d831ec7",
@@ -4442,8 +4442,8 @@
         "transactionIndex": "0x5b"
       }
     ],
-    null,
-    null
+    [],
+    []
   ]
         }
     }

--- a/integration/mainnet/erigon_getLogsByHash/test_03.json
+++ b/integration/mainnet/erigon_getLogsByHash/test_03.json
@@ -10,11 +10,11 @@
            "id": 1,
            "jsonrpc": "2.0",
   "result": [
-    null,
-    null,
-    null,
-    null,
-    null,
+    [],
+    [],
+    [],
+    [],
+    [],
     [
       {
         "address": "0xced4e93198734ddaff8492d525bd258d49eb388e",
@@ -83,9 +83,9 @@
         "transactionIndex": "0x7"
       }
     ],
-    null,
-    null,
-    null,
+    [],
+    [],
+    [],
     [
       {
         "address": "0xa5c43fff568fc2115d54499d4cf202bb490ef152",
@@ -154,8 +154,8 @@
         "transactionIndex": "0xe"
       }
     ],
-    null,
-    null,
+    [],
+    [],
     [
       {
         "address": "0xdac17f958d2ee523a2206206994597c13d831ec7",
@@ -206,7 +206,7 @@
         "transactionIndex": "0x12"
       }
     ],
-    null,
+    [],
     [
       {
         "address": "0x43cad9793fb8b72cadc63fd861bff2ddc9202892",
@@ -290,7 +290,7 @@
         "transactionIndex": "0x16"
       }
     ],
-    null,
+    [],
     [
       {
         "address": "0x8e870d67f660d95d5be530380d0ec0bd388289e1",
@@ -984,9 +984,9 @@
         "transactionIndex": "0x22"
       }
     ],
-    null,
-    null,
-    null,
+    [],
+    [],
+    [],
     [
       {
         "address": "0x2594d80da5f2e4f742d1e479eb9408aad132d0bd",
@@ -1197,10 +1197,10 @@
         "transactionIndex": "0x26"
       }
     ],
-    null,
-    null,
-    null,
-    null,
+    [],
+    [],
+    [],
+    [],
     [
       {
         "address": "0x2120887e9e4889653770b228ee8d13231d0ef045",
@@ -1217,8 +1217,8 @@
         "transactionIndex": "0x2b"
       }
     ],
-    null,
-    null,
+    [],
+    [],
     [
       {
         "address": "0x8e870d67f660d95d5be530380d0ec0bd388289e1",
@@ -1236,8 +1236,8 @@
         "transactionIndex": "0x2e"
       }
     ],
-    null,
-    null,
+    [],
+    [],
     [
       {
         "address": "0x95a41fb80ca70306e9ecf4e51cea31bd18379c18",
@@ -1323,8 +1323,8 @@
         "transactionIndex": "0x35"
       }
     ],
-    null,
-    null,
+    [],
+    [],
     [
       {
         "address": "0x06012c8cf97bead5deae237070f9587f8e7a266d",
@@ -1545,7 +1545,7 @@
         "transactionIndex": "0x40"
       }
     ],
-    null,
+    [],
     [
       {
         "address": "0x9b62ec1453cea5dde760aaf662048ca6eeb66e7f",
@@ -1660,9 +1660,9 @@
         "transactionIndex": "0x46"
       }
     ],
-    null,
-    null,
-    null,
+    [],
+    [],
+    [],
     [
       {
         "address": "0x06012c8cf97bead5deae237070f9587f8e7a266d",
@@ -1708,8 +1708,8 @@
         "transactionIndex": "0x4b"
       }
     ],
-    null,
-    null,
+    [],
+    [],
     [
       {
         "address": "0x0000000000085d4780b73119b644ae5ecd22b376",
@@ -1994,8 +1994,8 @@
         "transactionIndex": "0x58"
       }
     ],
-    null,
-    null,
+    [],
+    [],
     [
       {
         "address": "0x8e870d67f660d95d5be530380d0ec0bd388289e1",
@@ -2064,7 +2064,7 @@
         "transactionIndex": "0x5e"
       }
     ],
-    null,
+    [],
     [
       {
         "address": "0xc011a72400e58ecd99ee497cf89e3775d4bd732f",
@@ -2115,7 +2115,7 @@
         "transactionIndex": "0x61"
       }
     ],
-    null,
+    [],
     [
       {
         "address": "0xdac17f958d2ee523a2206206994597c13d831ec7",
@@ -2133,9 +2133,9 @@
         "transactionIndex": "0x63"
       }
     ],
-    null,
-    null,
-    null
+    [],
+    [],
+    []
   ]
         }
     }

--- a/integration/mainnet/erigon_getLogsByHash/test_05.json
+++ b/integration/mainnet/erigon_getLogsByHash/test_05.json
@@ -658,9 +658,9 @@
         "transactionIndex": "0x8"
       }
     ],
-    null,
-    null,
-    null,
+    [],
+    [],
+    [],
     [
       {
         "address": "0x5df7511872ba85626cf1ccedbcefc347edc2375e",
@@ -804,8 +804,8 @@
         "transactionIndex": "0x10"
       }
     ],
-    null,
-    null,
+    [],
+    [],
     [
       {
         "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -882,7 +882,7 @@
         "transactionIndex": "0x13"
       }
     ],
-    null,
+    [],
     [
       {
         "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
@@ -965,15 +965,15 @@
         "transactionIndex": "0x18"
       }
     ],
-    null,
-    null,
-    null,
-    null,
-    null,
-    null,
-    null,
-    null,
-    null,
+    [],
+    [],
+    [],
+    [],
+    [],
+    [],
+    [],
+    [],
+    [],
     [
       {
         "address": "0x4a24c1989e5dff0de40f5804b47623b6b4300b04",
@@ -1334,7 +1334,7 @@
         "transactionIndex": "0x29"
       }
     ],
-    null,
+    [],
     [
       {
         "address": "0xdac17f958d2ee523a2206206994597c13d831ec7",
@@ -1386,8 +1386,8 @@
         "transactionIndex": "0x2d"
       }
     ],
-    null,
-    null,
+    [],
+    [],
     [
       {
         "address": "0xdac17f958d2ee523a2206206994597c13d831ec7",
@@ -1405,7 +1405,7 @@
         "transactionIndex": "0x30"
       }
     ],
-    null,
+    [],
     [
       {
         "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -1423,7 +1423,7 @@
         "transactionIndex": "0x32"
       }
     ],
-    null,
+    [],
     [
       {
         "address": "0x000000000022d473030f116ddee9f6b43ac78ba3",
@@ -1722,7 +1722,7 @@
         "transactionIndex": "0x37"
       }
     ],
-    null,
+    [],
     [
       {
         "address": "0xd68356dcf4c619474901ea27f4f06bdf8cd3a2e7",
@@ -1828,7 +1828,7 @@
         "transactionIndex": "0x39"
       }
     ],
-    null,
+    [],
     [
       {
         "address": "0x86ac86af1fd9a2cb586a19e325be5d68439a6f31",
@@ -1983,9 +1983,9 @@
         "transactionIndex": "0x3c"
       }
     ],
-    null,
-    null,
-    null,
+    [],
+    [],
+    [],
     [
       {
         "address": "0x6120991c423f3566753d3c6c91a5b50d7d2461b4",
@@ -2358,8 +2358,8 @@
         "transactionIndex": "0x43"
       }
     ],
-    null,
-    null,
+    [],
+    [],
     [
       {
         "address": "0x0fe0ed7f146cb12e4b9759aff4fa8d34571802ca",
@@ -2377,7 +2377,7 @@
         "transactionIndex": "0x46"
       }
     ],
-    null,
+    [],
     [
       {
         "address": "0x00000000000001ad428e4906ae43d8f9852d0dd6",
@@ -2695,8 +2695,8 @@
         "transactionIndex": "0x4b"
       }
     ],
-    null,
-    null,
+    [],
+    [],
     [
       {
         "address": "0xa01d803e2734c542d13a13772deced63cd6453bf",
@@ -3428,7 +3428,7 @@
         "transactionIndex": "0x56"
       }
     ],
-    null,
+    [],
     [
       {
         "address": "0x3cf314571da3e56eaee61af2b30af56f75d3a602",
@@ -3645,7 +3645,7 @@
         "transactionIndex": "0x5f"
       }
     ],
-    null,
+    [],
     [
       {
         "address": "0x55ab51bea076e9f0c9549b5a0a806635900b5db0",
@@ -3691,9 +3691,9 @@
         "transactionIndex": "0x62"
       }
     ],
-    null,
-    null,
-    null
+    [],
+    [],
+    []
   ]
         }
     }

--- a/integration/mainnet/erigon_getLogsByHash/test_06.json
+++ b/integration/mainnet/erigon_getLogsByHash/test_06.json
@@ -10,8 +10,8 @@
            "id": 1,
            "jsonrpc": "2.0",
   "result": [
-    null,
-    null,
+    [],
+    [],
     [
       {
         "address": "0xe5caef4af8780e59df925470b050fb23c43ca68c",
@@ -63,7 +63,7 @@
         "transactionIndex": "0x4"
       }
     ],
-    null,
+    [],
     [
       {
         "address": "0xb7cb1c96db6b22b0d3d9536e0108d062bd488f74",
@@ -132,7 +132,7 @@
         "transactionIndex": "0x9"
       }
     ],
-    null,
+    [],
     [
       {
         "address": "0xdac17f958d2ee523a2206206994597c13d831ec7",
@@ -201,7 +201,7 @@
         "transactionIndex": "0xe"
       }
     ],
-    null,
+    [],
     [
       {
         "address": "0x287eefa72433f1684e16e067b28299190c93f128",
@@ -338,8 +338,8 @@
         "transactionIndex": "0x17"
       }
     ],
-    null,
-    null,
+    [],
+    [],
     [
       {
         "address": "0x5d6c182fe79640e1866a74458c5d800d3c58cee2",
@@ -355,7 +355,7 @@
         "transactionIndex": "0x1a"
       }
     ],
-    null,
+    [],
     [
       {
         "address": "0xdac17f958d2ee523a2206206994597c13d831ec7",
@@ -373,8 +373,8 @@
         "transactionIndex": "0x1c"
       }
     ],
-    null,
-    null,
+    [],
+    [],
     [
       {
         "address": "0xdac17f958d2ee523a2206206994597c13d831ec7",
@@ -392,10 +392,10 @@
         "transactionIndex": "0x1f"
       }
     ],
-    null,
-    null,
-    null,
-    null,
+    [],
+    [],
+    [],
+    [],
     [
       {
         "address": "0xdac17f958d2ee523a2206206994597c13d831ec7",
@@ -460,21 +460,21 @@
         "transactionIndex": "0x27"
       }
     ],
-    null,
-    null,
-    null,
-    null,
-    null,
-    null,
-    null,
-    null,
-    null,
-    null,
-    null,
-    null,
-    null,
-    null,
-    null,
+    [],
+    [],
+    [],
+    [],
+    [],
+    [],
+    [],
+    [],
+    [],
+    [],
+    [],
+    [],
+    [],
+    [],
+    [],
     [
       {
         "address": "0x1680cfdad75da2bb56ded4f36bb9423c86ffa7b7",
@@ -508,7 +508,7 @@
         "transactionIndex": "0x38"
       }
     ],
-    null,
+    [],
     [
       {
         "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
@@ -558,7 +558,7 @@
         "transactionIndex": "0x3b"
       }
     ],
-    null,
+    [],
     [
       {
         "address": "0x4f9254c83eb525f9fcf346490bbb3ed28a81c667",
@@ -576,24 +576,24 @@
         "transactionIndex": "0x3d"
       }
     ],
-    null,
-    null,
-    null,
-    null,
-    null,
-    null,
-    null,
-    null,
-    null,
-    null,
-    null,
-    null,
-    null,
-    null,
-    null,
-    null,
-    null,
-    null,
+    [],
+    [],
+    [],
+    [],
+    [],
+    [],
+    [],
+    [],
+    [],
+    [],
+    [],
+    [],
+    [],
+    [],
+    [],
+    [],
+    [],
+    [],
     [
       {
         "address": "0xf629cbd94d3791c9250152bd8dfbdf380e2a3b9c",
@@ -628,10 +628,10 @@
         "transactionIndex": "0x51"
       }
     ],
-    null,
-    null,
-    null,
-    null,
+    [],
+    [],
+    [],
+    [],
     [
       {
         "address": "0x56c438ee032224d93a5e9f182cbf4608cdfc928e",
@@ -664,10 +664,10 @@
         "transactionIndex": "0x57"
       }
     ],
-    null,
-    null,
-    null,
-    null,
+    [],
+    [],
+    [],
+    [],
     [
       {
         "address": "0xe72752f55e69052ef40d989a843b9fa59e88b26b",
@@ -684,8 +684,8 @@
         "transactionIndex": "0x5c"
       }
     ],
-    null,
-    null
+    [],
+    []
   ]
         }
     }

--- a/integration/mainnet/erigon_getLogsByHash/test_07.json
+++ b/integration/mainnet/erigon_getLogsByHash/test_07.json
@@ -10,7 +10,7 @@
            "id": 1,
            "jsonrpc": "2.0",
   "result": [
-    null,
+    [],
     [
       {
         "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -2388,7 +2388,7 @@
         "transactionIndex": "0x17"
       }
     ],
-    null,
+    [],
     [
       {
         "address": "0x923a20ca8193c8634b8901c20df9e00afc99291a",
@@ -2676,7 +2676,7 @@
         "transactionIndex": "0x1c"
       }
     ],
-    null,
+    [],
     [
       {
         "address": "0x7d1afa7b718fb893db30a3abc0cfc608aacfebb0",
@@ -2709,7 +2709,7 @@
         "transactionIndex": "0x1e"
       }
     ],
-    null,
+    [],
     [
       {
         "address": "0x3aada3e213abf8529606924d8d1c55cbdc70bf74",
@@ -2900,7 +2900,7 @@
         "transactionIndex": "0x24"
       }
     ],
-    null,
+    [],
     [
       {
         "address": "0xdac17f958d2ee523a2206206994597c13d831ec7",
@@ -2918,7 +2918,7 @@
         "transactionIndex": "0x26"
       }
     ],
-    null,
+    [],
     [
       {
         "address": "0x967da4048cd07ab37855c090aaf366e4ce1b9f48",
@@ -3000,8 +3000,8 @@
         "transactionIndex": "0x2c"
       }
     ],
-    null,
-    null,
+    [],
+    [],
     [
       {
         "address": "0xdac17f958d2ee523a2206206994597c13d831ec7",
@@ -3019,18 +3019,18 @@
         "transactionIndex": "0x2f"
       }
     ],
-    null,
-    null,
-    null,
-    null,
-    null,
-    null,
-    null,
-    null,
-    null,
-    null,
-    null,
-    null,
+    [],
+    [],
+    [],
+    [],
+    [],
+    [],
+    [],
+    [],
+    [],
+    [],
+    [],
+    [],
     [
       {
         "address": "0x2b7e3ca44ba205763e1dbfb41bed10ff847d3228",
@@ -3164,7 +3164,7 @@
         "transactionIndex": "0x42"
       }
     ],
-    null,
+    [],
     [
       {
         "address": "0x43af0944b34ad466dcea7fc8f77aafc6a4ec70fa",
@@ -3267,7 +3267,7 @@
         "transactionIndex": "0x49"
       }
     ],
-    null,
+    [],
     [
       {
         "address": "0x49048044d57e1c92a77f79988d21fa8faf74e97e",
@@ -3303,8 +3303,8 @@
         "transactionIndex": "0x4c"
       }
     ],
-    null,
-    null,
+    [],
+    [],
     [
       {
         "address": "0x8d0802559775c70fb505f22988a4fd4a4f6d3b62",
@@ -3463,7 +3463,7 @@
         "transactionIndex": "0x53"
       }
     ],
-    null,
+    [],
     [
       {
         "address": "0xdac17f958d2ee523a2206206994597c13d831ec7",
@@ -4504,7 +4504,7 @@
         "transactionIndex": "0x63"
       }
     ],
-    null,
+    [],
     [
       {
         "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -4941,9 +4941,9 @@
         "transactionIndex": "0x69"
       }
     ],
-    null,
-    null,
-    null,
+    [],
+    [],
+    [],
     [
       {
         "address": "0xe6b738da243e8fa2a0ed5915645789add5de5152",
@@ -5044,11 +5044,11 @@
         "transactionIndex": "0x6d"
       }
     ],
-    null,
-    null,
-    null,
-    null,
-    null,
+    [],
+    [],
+    [],
+    [],
+    [],
     [
       {
         "address": "0x1142866f451d9d5281c5c8349a332bd338e552a1",
@@ -5124,15 +5124,15 @@
         "transactionIndex": "0x73"
       }
     ],
-    null,
-    null,
-    null,
-    null,
-    null,
-    null,
-    null,
-    null,
-    null,
+    [],
+    [],
+    [],
+    [],
+    [],
+    [],
+    [],
+    [],
+    [],
     [
       {
         "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -5150,8 +5150,8 @@
         "transactionIndex": "0x7d"
       }
     ],
-    null,
-    null,
+    [],
+    [],
     [
       {
         "address": "0x8d0802559775c70fb505f22988a4fd4a4f6d3b62",
@@ -5333,7 +5333,7 @@
         "transactionIndex": "0x82"
       }
     ],
-    null
+    []
   ]
         }
     }

--- a/integration/mainnet/erigon_getLogsByHash/test_08.json
+++ b/integration/mainnet/erigon_getLogsByHash/test_08.json
@@ -235,8 +235,8 @@
         "transactionIndex": "0x2"
       }
     ],
-    null,
-    null,
+    [],
+    [],
     [
       {
         "address": "0xdac17f958d2ee523a2206206994597c13d831ec7",
@@ -254,10 +254,10 @@
         "transactionIndex": "0x5"
       }
     ],
-    null,
-    null,
-    null,
-    null,
+    [],
+    [],
+    [],
+    [],
     [
       {
         "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -949,7 +949,7 @@
         "transactionIndex": "0xf"
       }
     ],
-    null,
+    [],
     [
       {
         "address": "0x9813037ee2218799597d83d4a5b6f3b6778218d9",
@@ -1256,7 +1256,7 @@
         "transactionIndex": "0x16"
       }
     ],
-    null,
+    [],
     [
       {
         "address": "0x08d0222a206d1aee59a9b66969c04fd1e8a0f864",
@@ -1362,9 +1362,9 @@
         "transactionIndex": "0x19"
       }
     ],
-    null,
-    null,
-    null,
+    [],
+    [],
+    [],
     [
       {
         "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -1597,16 +1597,16 @@
         "transactionIndex": "0x22"
       }
     ],
-    null,
-    null,
-    null,
-    null,
-    null,
-    null,
-    null,
-    null,
-    null,
-    null,
+    [],
+    [],
+    [],
+    [],
+    [],
+    [],
+    [],
+    [],
+    [],
+    [],
     [
       {
         "address": "0xf2261b0e8d8e432e1e49dd9555c57c997e14ffed",
@@ -1641,9 +1641,9 @@
         "transactionIndex": "0x2e"
       }
     ],
-    null,
-    null,
-    null,
+    [],
+    [],
+    [],
     [
       {
         "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -1942,7 +1942,7 @@
         "transactionIndex": "0x34"
       }
     ],
-    null,
+    [],
     [
       {
         "address": "0xdac17f958d2ee523a2206206994597c13d831ec7",
@@ -2282,7 +2282,7 @@
         "transactionIndex": "0x3d"
       }
     ],
-    null,
+    [],
     [
       {
         "address": "0x929a2a7acfaf5342ca3b894f83a823a7e333b851",
@@ -2300,7 +2300,7 @@
         "transactionIndex": "0x3f"
       }
     ],
-    null,
+    [],
     [
       {
         "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -2513,7 +2513,7 @@
         "transactionIndex": "0x44"
       }
     ],
-    null,
+    [],
     [
       {
         "address": "0x5bffe8ddff21ca52d8371b14a6c39d6ae3c5d2c7",
@@ -2653,7 +2653,7 @@
         "transactionIndex": "0x49"
       }
     ],
-    null,
+    [],
     [
       {
         "address": "0xbe3026082402c7bb344729ce3a51b259bf1e5915",
@@ -2967,17 +2967,17 @@
         "transactionIndex": "0x4d"
       }
     ],
-    null,
-    null,
-    null,
-    null,
-    null,
-    null,
-    null,
-    null,
-    null,
-    null,
-    null,
+    [],
+    [],
+    [],
+    [],
+    [],
+    [],
+    [],
+    [],
+    [],
+    [],
+    [],
     [
       {
         "address": "0xdac17f958d2ee523a2206206994597c13d831ec7",
@@ -2995,8 +2995,8 @@
         "transactionIndex": "0x59"
       }
     ],
-    null,
-    null,
+    [],
+    [],
     [
       {
         "address": "0x9138c8779a0ac8a84d69617d5715bd8afa23c650",
@@ -3209,8 +3209,8 @@
         "transactionIndex": "0x5f"
       }
     ],
-    null,
-    null,
+    [],
+    [],
     [
       {
         "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -3423,8 +3423,8 @@
         "transactionIndex": "0x63"
       }
     ],
-    null,
-    null,
+    [],
+    [],
     [
       {
         "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -3549,13 +3549,13 @@
         "transactionIndex": "0x6a"
       }
     ],
-    null,
-    null,
-    null,
-    null,
-    null,
-    null,
-    null,
+    [],
+    [],
+    [],
+    [],
+    [],
+    [],
+    [],
     [
       {
         "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -3604,7 +3604,7 @@
         "transactionIndex": "0x73"
       }
     ],
-    null,
+    [],
     [
       {
         "address": "0xfd14567eaf9ba941cb8c8a94eec14831ca7fd1b4",
@@ -3620,8 +3620,8 @@
         "transactionIndex": "0x75"
       }
     ],
-    null,
-    null,
+    [],
+    [],
     [
       {
         "address": "0x25bccb01c9fcdead6444aab5695d7026abcd27a0",
@@ -3784,7 +3784,7 @@
         "transactionIndex": "0x79"
       }
     ],
-    null,
+    [],
     [
       {
         "address": "0x1142866f451d9d5281c5c8349a332bd338e552a1",
@@ -3874,7 +3874,7 @@
         "transactionIndex": "0x7b"
       }
     ],
-    null,
+    [],
     [
       {
         "address": "0xdac17f958d2ee523a2206206994597c13d831ec7",
@@ -3892,7 +3892,7 @@
         "transactionIndex": "0x7d"
       }
     ],
-    null
+    []
   ]
         }
     }

--- a/integration/mainnet/erigon_getLogsByHash/test_09.json
+++ b/integration/mainnet/erigon_getLogsByHash/test_09.json
@@ -1716,7 +1716,7 @@
         "transactionIndex": "0xa"
       }
     ],
-    null,
+    [],
     [
       {
         "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -1999,8 +1999,8 @@
         "transactionIndex": "0xe"
       }
     ],
-    null,
-    null,
+    [],
+    [],
     [
       {
         "address": "0xd1d2eb1b1e90b638588728b4130137d262c87cae",
@@ -2018,7 +2018,7 @@
         "transactionIndex": "0x11"
       }
     ],
-    null,
+    [],
     [
       {
         "address": "0x0c3d8b3ba891310107f1d2ff99f406ed27599151",
@@ -2035,11 +2035,11 @@
         "transactionIndex": "0x13"
       }
     ],
-    null,
-    null,
-    null,
-    null,
-    null,
+    [],
+    [],
+    [],
+    [],
+    [],
     [
       {
         "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -2114,9 +2114,9 @@
         "transactionIndex": "0x19"
       }
     ],
-    null,
-    null,
-    null,
+    [],
+    [],
+    [],
     [
       {
         "address": "0x7420b4b9a0110cdc71fb720908340c03f9bc03ec",
@@ -2134,7 +2134,7 @@
         "transactionIndex": "0x1d"
       }
     ],
-    null,
+    [],
     [
       {
         "address": "0xdac17f958d2ee523a2206206994597c13d831ec7",
@@ -2152,8 +2152,8 @@
         "transactionIndex": "0x1f"
       }
     ],
-    null,
-    null,
+    [],
+    [],
     [
       {
         "address": "0xdac17f958d2ee523a2206206994597c13d831ec7",
@@ -2171,8 +2171,8 @@
         "transactionIndex": "0x22"
       }
     ],
-    null,
-    null,
+    [],
+    [],
     [
       {
         "address": "0x8d0802559775c70fb505f22988a4fd4a4f6d3b62",
@@ -2204,7 +2204,7 @@
         "transactionIndex": "0x25"
       }
     ],
-    null,
+    [],
     [
       {
         "address": "0x6982508145454ce325ddbe47a25d4ec3d2311933",
@@ -2370,7 +2370,7 @@
         "transactionIndex": "0x27"
       }
     ],
-    null,
+    [],
     [
       {
         "address": "0x751826b107672360b764327631cc5764515ffc37",
@@ -2387,7 +2387,7 @@
         "transactionIndex": "0x29"
       }
     ],
-    null,
+    [],
     [
       {
         "address": "0x6541e93492d87a2b6b896e0086c2814a3dda4990",
@@ -2405,7 +2405,7 @@
         "transactionIndex": "0x2b"
       }
     ],
-    null,
+    [],
     [
       {
         "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -2584,8 +2584,8 @@
         "transactionIndex": "0x2e"
       }
     ],
-    null,
-    null,
+    [],
+    [],
     [
       {
         "address": "0xdac17f958d2ee523a2206206994597c13d831ec7",
@@ -2773,10 +2773,10 @@
         "transactionIndex": "0x3b"
       }
     ],
-    null,
-    null,
-    null,
-    null,
+    [],
+    [],
+    [],
+    [],
     [
       {
         "address": "0xdac17f958d2ee523a2206206994597c13d831ec7",
@@ -2794,8 +2794,8 @@
         "transactionIndex": "0x40"
       }
     ],
-    null,
-    null,
+    [],
+    [],
     [
       {
         "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -2813,19 +2813,19 @@
         "transactionIndex": "0x43"
       }
     ],
-    null,
-    null,
-    null,
-    null,
-    null,
-    null,
-    null,
-    null,
-    null,
-    null,
-    null,
-    null,
-    null,
+    [],
+    [],
+    [],
+    [],
+    [],
+    [],
+    [],
+    [],
+    [],
+    [],
+    [],
+    [],
+    [],
     [
       {
         "address": "0xdac17f958d2ee523a2206206994597c13d831ec7",
@@ -2843,16 +2843,16 @@
         "transactionIndex": "0x51"
       }
     ],
-    null,
-    null,
-    null,
-    null,
-    null,
-    null,
-    null,
-    null,
-    null,
-    null,
+    [],
+    [],
+    [],
+    [],
+    [],
+    [],
+    [],
+    [],
+    [],
+    [],
     [
       {
         "address": "0xdac17f958d2ee523a2206206994597c13d831ec7",
@@ -2870,8 +2870,8 @@
         "transactionIndex": "0x5c"
       }
     ],
-    null,
-    null,
+    [],
+    [],
     [
       {
         "address": "0x95ad61b0a150d79219dcf64e1e6cc01f0b64c4ce",
@@ -2906,7 +2906,7 @@
         "transactionIndex": "0x60"
       }
     ],
-    null,
+    [],
     [
       {
         "address": "0xdac17f958d2ee523a2206206994597c13d831ec7",
@@ -2941,8 +2941,8 @@
         "transactionIndex": "0x63"
       }
     ],
-    null,
-    null,
+    [],
+    [],
     [
       {
         "address": "0xdac17f958d2ee523a2206206994597c13d831ec7",
@@ -2977,7 +2977,7 @@
         "transactionIndex": "0x67"
       }
     ],
-    null,
+    [],
     [
       {
         "address": "0xdac17f958d2ee523a2206206994597c13d831ec7",
@@ -2995,8 +2995,8 @@
         "transactionIndex": "0x69"
       }
     ],
-    null,
-    null,
+    [],
+    [],
     [
       {
         "address": "0xdac17f958d2ee523a2206206994597c13d831ec7",
@@ -3048,22 +3048,22 @@
         "transactionIndex": "0x6e"
       }
     ],
-    null,
-    null,
-    null,
-    null,
-    null,
-    null,
-    null,
-    null,
-    null,
-    null,
-    null,
-    null,
-    null,
-    null,
-    null,
-    null,
+    [],
+    [],
+    [],
+    [],
+    [],
+    [],
+    [],
+    [],
+    [],
+    [],
+    [],
+    [],
+    [],
+    [],
+    [],
+    [],
     [
       {
         "address": "0xdac17f958d2ee523a2206206994597c13d831ec7",
@@ -3081,9 +3081,9 @@
         "transactionIndex": "0x7f"
       }
     ],
-    null,
-    null,
-    null,
+    [],
+    [],
+    [],
     [
       {
         "address": "0xdac17f958d2ee523a2206206994597c13d831ec7",
@@ -3118,8 +3118,8 @@
         "transactionIndex": "0x84"
       }
     ],
-    null,
-    null,
+    [],
+    [],
     [
       {
         "address": "0xdac17f958d2ee523a2206206994597c13d831ec7",
@@ -3137,9 +3137,9 @@
         "transactionIndex": "0x87"
       }
     ],
-    null,
-    null,
-    null,
+    [],
+    [],
+    [],
     [
       {
         "address": "0xdac17f958d2ee523a2206206994597c13d831ec7",
@@ -3259,8 +3259,8 @@
         "transactionIndex": "0x91"
       }
     ],
-    null,
-    null,
+    [],
+    [],
     [
       {
         "address": "0xdac17f958d2ee523a2206206994597c13d831ec7",
@@ -3278,7 +3278,7 @@
         "transactionIndex": "0x94"
       }
     ],
-    null,
+    [],
     [
       {
         "address": "0xdac17f958d2ee523a2206206994597c13d831ec7",
@@ -3313,10 +3313,10 @@
         "transactionIndex": "0x97"
       }
     ],
-    null,
-    null,
-    null,
-    null,
+    [],
+    [],
+    [],
+    [],
     [
       {
         "address": "0xdac17f958d2ee523a2206206994597c13d831ec7",
@@ -3334,7 +3334,7 @@
         "transactionIndex": "0x9c"
       }
     ],
-    null,
+    [],
     [
       {
         "address": "0xdac17f958d2ee523a2206206994597c13d831ec7",
@@ -3352,8 +3352,8 @@
         "transactionIndex": "0x9e"
       }
     ],
-    null,
-    null,
+    [],
+    [],
     [
       {
         "address": "0xdac17f958d2ee523a2206206994597c13d831ec7",
@@ -3405,7 +3405,7 @@
         "transactionIndex": "0xa3"
       }
     ],
-    null,
+    [],
     [
       {
         "address": "0xdac17f958d2ee523a2206206994597c13d831ec7",
@@ -3457,7 +3457,7 @@
         "transactionIndex": "0xa7"
       }
     ],
-    null,
+    [],
     [
       {
         "address": "0xdac17f958d2ee523a2206206994597c13d831ec7",
@@ -3475,7 +3475,7 @@
         "transactionIndex": "0xa9"
       }
     ],
-    null,
+    [],
     [
       {
         "address": "0xdac17f958d2ee523a2206206994597c13d831ec7",
@@ -3493,8 +3493,8 @@
         "transactionIndex": "0xab"
       }
     ],
-    null,
-    null,
+    [],
+    [],
     [
       {
         "address": "0xdac17f958d2ee523a2206206994597c13d831ec7",
@@ -3512,7 +3512,7 @@
         "transactionIndex": "0xae"
       }
     ],
-    null,
+    [],
     [
       {
         "address": "0xdac17f958d2ee523a2206206994597c13d831ec7",
@@ -3598,7 +3598,7 @@
         "transactionIndex": "0xb4"
       }
     ],
-    null,
+    [],
     [
       {
         "address": "0xdac17f958d2ee523a2206206994597c13d831ec7",
@@ -3616,8 +3616,8 @@
         "transactionIndex": "0xb6"
       }
     ],
-    null,
-    null,
+    [],
+    [],
     [
       {
         "address": "0xdac17f958d2ee523a2206206994597c13d831ec7",
@@ -3652,9 +3652,9 @@
         "transactionIndex": "0xba"
       }
     ],
-    null,
-    null,
-    null,
+    [],
+    [],
+    [],
     [
       {
         "address": "0xdac17f958d2ee523a2206206994597c13d831ec7",
@@ -3672,7 +3672,7 @@
         "transactionIndex": "0xbe"
       }
     ],
-    null,
+    [],
     [
       {
         "address": "0xdac17f958d2ee523a2206206994597c13d831ec7",
@@ -3690,8 +3690,8 @@
         "transactionIndex": "0xc0"
       }
     ],
-    null,
-    null,
+    [],
+    [],
     [
       {
         "address": "0xdac17f958d2ee523a2206206994597c13d831ec7",
@@ -3709,7 +3709,7 @@
         "transactionIndex": "0xc3"
       }
     ],
-    null,
+    [],
     [
       {
         "address": "0xdac17f958d2ee523a2206206994597c13d831ec7",
@@ -3795,11 +3795,11 @@
         "transactionIndex": "0xc9"
       }
     ],
-    null,
-    null,
-    null,
-    null,
-    null,
+    [],
+    [],
+    [],
+    [],
+    [],
     [
       {
         "address": "0xdac17f958d2ee523a2206206994597c13d831ec7",
@@ -3817,10 +3817,10 @@
         "transactionIndex": "0xcf"
       }
     ],
-    null,
-    null,
-    null,
-    null,
+    [],
+    [],
+    [],
+    [],
     [
       {
         "address": "0x88df592f8eb5d7bd38bfef7deb0fbc02cf3778a0",
@@ -3855,8 +3855,8 @@
         "transactionIndex": "0xd5"
       }
     ],
-    null,
-    null,
+    [],
+    [],
     [
       {
         "address": "0xef3a930e1ffffacd2fc13434ac81bd278b0ecc8d",
@@ -3874,7 +3874,7 @@
         "transactionIndex": "0xd8"
       }
     ],
-    null,
+    [],
     [
       {
         "address": "0xdac17f958d2ee523a2206206994597c13d831ec7",
@@ -3926,7 +3926,7 @@
         "transactionIndex": "0xdc"
       }
     ],
-    null,
+    [],
     [
       {
         "address": "0xdac17f958d2ee523a2206206994597c13d831ec7",
@@ -3944,9 +3944,9 @@
         "transactionIndex": "0xde"
       }
     ],
-    null,
-    null,
-    null,
+    [],
+    [],
+    [],
     [
       {
         "address": "0xdac17f958d2ee523a2206206994597c13d831ec7",
@@ -4576,34 +4576,34 @@
         "transactionIndex": "0x106"
       }
     ],
-    null,
-    null,
-    null,
-    null,
-    null,
-    null,
-    null,
-    null,
-    null,
-    null,
-    null,
-    null,
-    null,
-    null,
-    null,
-    null,
-    null,
-    null,
-    null,
-    null,
-    null,
-    null,
-    null,
-    null,
-    null,
-    null,
-    null,
-    null,
+    [],
+    [],
+    [],
+    [],
+    [],
+    [],
+    [],
+    [],
+    [],
+    [],
+    [],
+    [],
+    [],
+    [],
+    [],
+    [],
+    [],
+    [],
+    [],
+    [],
+    [],
+    [],
+    [],
+    [],
+    [],
+    [],
+    [],
+    [],
     [
       {
         "address": "0x6c3f90f043a72fa612cbac8115ee7e52bde6e490",
@@ -4655,7 +4655,7 @@
         "transactionIndex": "0x125"
       }
     ],
-    null,
+    [],
     [
       {
         "address": "0x473037de59cf9484632f4a27b509cfe8d4a31404",
@@ -4673,7 +4673,7 @@
         "transactionIndex": "0x127"
       }
     ],
-    null,
+    [],
     [
       {
         "address": "0xca5001bc5134302dbe0f798a2d0b95ef3cf0803f",
@@ -4958,13 +4958,13 @@
         "transactionIndex": "0x12a"
       }
     ],
-    null,
-    null,
-    null,
-    null,
-    null,
-    null,
-    null,
+    [],
+    [],
+    [],
+    [],
+    [],
+    [],
+    [],
     [
       {
         "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -5088,7 +5088,7 @@
         "transactionIndex": "0x134"
       }
     ],
-    null,
+    [],
     [
       {
         "address": "0xad574c1b36cb5f03eb471a9501c4ccff8040dd2d",
@@ -5422,7 +5422,7 @@
         "transactionIndex": "0x13b"
       }
     ],
-    null,
+    [],
     [
       {
         "address": "0x58b6a8a3302369daec383334672404ee733ab239",
@@ -5440,7 +5440,7 @@
         "transactionIndex": "0x13d"
       }
     ],
-    null,
+    [],
     [
       {
         "address": "0x000000000022d473030f116ddee9f6b43ac78ba3",
@@ -6008,7 +6008,7 @@
         "transactionIndex": "0x146"
       }
     ],
-    null,
+    [],
     [
       {
         "address": "0x000000000022d473030f116ddee9f6b43ac78ba3",
@@ -6246,8 +6246,8 @@
         "transactionIndex": "0x148"
       }
     ],
-    null,
-    null,
+    [],
+    [],
     [
       {
         "address": "0xa6821d627f1078b48873aeacd08df8072c57c677",
@@ -6357,10 +6357,10 @@
         "transactionIndex": "0x14c"
       }
     ],
-    null,
-    null,
-    null,
-    null,
+    [],
+    [],
+    [],
+    [],
     [
       {
         "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -6692,11 +6692,11 @@
         "transactionIndex": "0x155"
       }
     ],
-    null,
-    null,
-    null,
-    null,
-    null,
+    [],
+    [],
+    [],
+    [],
+    [],
     [
       {
         "address": "0x07da4c5260c678a3acb554bd295b98d313f5502d",
@@ -6731,8 +6731,8 @@
         "transactionIndex": "0x15c"
       }
     ],
-    null,
-    null,
+    [],
+    [],
     [
       {
         "address": "0x22987ad161b7c0fcf7cb73734a01322ed901c418",
@@ -6837,8 +6837,8 @@
         "transactionIndex": "0x160"
       }
     ],
-    null,
-    null,
+    [],
+    [],
     [
       {
         "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -6928,8 +6928,8 @@
         "transactionIndex": "0x163"
       }
     ],
-    null,
-    null
+    [],
+    []
   ]
         }
     }

--- a/integration/mainnet/erigon_getLogsByHash/test_10.json
+++ b/integration/mainnet/erigon_getLogsByHash/test_10.json
@@ -1301,7 +1301,7 @@
         "transactionIndex": "0x10"
       }
     ],
-    null,
+    [],
     [
       {
         "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -1391,8 +1391,8 @@
         "transactionIndex": "0x12"
       }
     ],
-    null,
-    null,
+    [],
+    [],
     [
       {
         "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -1901,7 +1901,7 @@
         "transactionIndex": "0x1b"
       }
     ],
-    null,
+    [],
     [
       {
         "address": "0xf5394f15c6fb73fc5f4da9e9f50f3aee729293b0",
@@ -2123,9 +2123,9 @@
         "transactionIndex": "0x1d"
       }
     ],
-    null,
-    null,
-    null,
+    [],
+    [],
+    [],
     [
       {
         "address": "0xbe87786b9015c92206ca9650b0512b0d59acb829",
@@ -3368,7 +3368,7 @@
         "transactionIndex": "0x29"
       }
     ],
-    null,
+    [],
     [
       {
         "address": "0x0948ff94d08eefe87ecc7b6942ebe37f65901f0e",
@@ -3731,8 +3731,8 @@
         "transactionIndex": "0x2e"
       }
     ],
-    null,
-    null,
+    [],
+    [],
     [
       {
         "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -3750,9 +3750,9 @@
         "transactionIndex": "0x31"
       }
     ],
-    null,
-    null,
-    null,
+    [],
+    [],
+    [],
     [
       {
         "address": "0xed04915c23f00a313a544955524eb7dbd823143d",
@@ -3770,8 +3770,8 @@
         "transactionIndex": "0x35"
       }
     ],
-    null,
-    null,
+    [],
+    [],
     [
       {
         "address": "0xdc63269ea166b70d4780b3a11f5c825c2b761b01",
@@ -3806,7 +3806,7 @@
         "transactionIndex": "0x39"
       }
     ],
-    null,
+    [],
     [
       {
         "address": "0xc944e90c64b2c07662a292be6244bdf05cda44a7",
@@ -3858,8 +3858,8 @@
         "transactionIndex": "0x3d"
       }
     ],
-    null,
-    null,
+    [],
+    [],
     [
       {
         "address": "0x000000000022d473030f116ddee9f6b43ac78ba3",
@@ -3999,7 +3999,7 @@
         "transactionIndex": "0x42"
       }
     ],
-    null,
+    [],
     [
       {
         "address": "0x00000000000000adc04c56bf30ac9d3c0aaf14dc",
@@ -4187,7 +4187,7 @@
         "transactionIndex": "0x46"
       }
     ],
-    null,
+    [],
     [
       {
         "address": "0xdac17f958d2ee523a2206206994597c13d831ec7",
@@ -4205,10 +4205,10 @@
         "transactionIndex": "0x48"
       }
     ],
-    null,
-    null,
-    null,
-    null,
+    [],
+    [],
+    [],
+    [],
     [
       {
         "address": "0x15d59b3358faa2f1b0df2b92a172b453fa9fd833",
@@ -4224,8 +4224,8 @@
         "transactionIndex": "0x4d"
       }
     ],
-    null,
-    null,
+    [],
+    [],
     [
       {
         "address": "0xdac17f958d2ee523a2206206994597c13d831ec7",
@@ -4243,7 +4243,7 @@
         "transactionIndex": "0x50"
       }
     ],
-    null,
+    [],
     [
       {
         "address": "0x25f8087ead173b73d6e8b84329989a8eea16cf73",
@@ -4304,12 +4304,12 @@
         "transactionIndex": "0x52"
       }
     ],
-    null,
-    null,
-    null,
-    null,
-    null,
-    null,
+    [],
+    [],
+    [],
+    [],
+    [],
+    [],
     [
       {
         "address": "0x020082a7a9c2510e1921116001152dee4da81985",
@@ -4353,7 +4353,7 @@
         "transactionIndex": "0x59"
       }
     ],
-    null,
+    [],
     [
       {
         "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -4918,8 +4918,8 @@
         "transactionIndex": "0x61"
       }
     ],
-    null,
-    null,
+    [],
+    [],
     [
       {
         "address": "0x95ad61b0a150d79219dcf64e1e6cc01f0b64c4ce",
@@ -4988,7 +4988,7 @@
         "transactionIndex": "0x67"
       }
     ],
-    null,
+    [],
     [
       {
         "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -5286,7 +5286,7 @@
         "transactionIndex": "0x70"
       }
     ],
-    null,
+    [],
     [
       {
         "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -5389,11 +5389,11 @@
         "transactionIndex": "0x72"
       }
     ],
-    null,
-    null,
-    null,
-    null,
-    null,
+    [],
+    [],
+    [],
+    [],
+    [],
     [
       {
         "address": "0xc00e94cb662c3520282e6f5717214004a7f26888",
@@ -5411,7 +5411,7 @@
         "transactionIndex": "0x78"
       }
     ],
-    null,
+    [],
     [
       {
         "address": "0x29469395eaf6f95920e59f858042f0e28d98a20b",
@@ -5668,7 +5668,7 @@
         "transactionIndex": "0x7d"
       }
     ],
-    null,
+    [],
     [
       {
         "address": "0x274e6946c928e7d3f960f3e8c7b6d6f6a2a391ca",
@@ -5825,10 +5825,10 @@
         "transactionIndex": "0x7f"
       }
     ],
-    null,
-    null,
-    null,
-    null,
+    [],
+    [],
+    [],
+    [],
     [
       {
         "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -5903,7 +5903,7 @@
         "transactionIndex": "0x84"
       }
     ],
-    null,
+    [],
     [
       {
         "address": "0xbb229e90141d819213acb0e91a92cc84c72ce711",
@@ -5971,8 +5971,8 @@
         "transactionIndex": "0x88"
       }
     ],
-    null,
-    null,
+    [],
+    [],
     [
       {
         "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -6051,7 +6051,7 @@
         "transactionIndex": "0x8c"
       }
     ],
-    null,
+    [],
     [
       {
         "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -6141,7 +6141,7 @@
         "transactionIndex": "0x8e"
       }
     ],
-    null,
+    [],
     [
       {
         "address": "0x000000000022d473030f116ddee9f6b43ac78ba3",
@@ -6472,7 +6472,7 @@
         "transactionIndex": "0x93"
       }
     ],
-    null,
+    [],
     [
       {
         "address": "0x000000000022d473030f116ddee9f6b43ac78ba3",
@@ -7201,8 +7201,8 @@
         "transactionIndex": "0x9f"
       }
     ],
-    null,
-    null,
+    [],
+    [],
     [
       {
         "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -7444,8 +7444,8 @@
         "transactionIndex": "0xa4"
       }
     ],
-    null,
-    null,
+    [],
+    [],
     [
       {
         "address": "0x9138c8779a0ac8a84d69617d5715bd8afa23c650",
@@ -7647,9 +7647,9 @@
         "transactionIndex": "0xaa"
       }
     ],
-    null,
-    null,
-    null,
+    [],
+    [],
+    [],
     [
       {
         "address": "0x046eee2cc3188071c02bfc1745a6b17c656e3f3d",
@@ -7667,9 +7667,9 @@
         "transactionIndex": "0xae"
       }
     ],
-    null,
-    null,
-    null,
+    [],
+    [],
+    [],
     [
       {
         "address": "0x57f1887a8bf19b14fc0df6fd9b2acc9af147ea85",
@@ -8028,9 +8028,9 @@
         "transactionIndex": "0xb5"
       }
     ],
-    null,
-    null,
-    null,
+    [],
+    [],
+    [],
     [
       {
         "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
@@ -8079,12 +8079,12 @@
         "transactionIndex": "0xba"
       }
     ],
-    null,
-    null,
-    null,
-    null,
-    null,
-    null,
+    [],
+    [],
+    [],
+    [],
+    [],
+    [],
     [
       {
         "address": "0x388c818ca8b9251b393131c08a736a67ccb19297",


### PR DESCRIPTION
Updates the expected results of `erigon_getLogsByHash` to match the upstream fix in erigontech/erigon#23430.

## Context

Before that PR, `erigon_getLogsByHash` only filled a slot of the result array when the corresponding receipt had logs:

```go
if len(receipt.Logs) > 0 {
    logs[i] = receipt.Logs
}
```

Every other slot was left `nil` and therefore serialized as `null`. A block containing only value transfers returned `[null]` instead of the documented `[[]]`, so any client iterating the inner element without a null check would break.

The upstream fix assigns every slot unconditionally and normalizes `nil` to an empty slice, so transactions with no logs now return `[]`.

## Notes

Draft until the upstream PR is merged and the tests are re-run against a node that includes it.