### PR TITLE
integration: ignore the tracer error field on debug_traceBlockByNumber latest tests

### DIFF
--- a/integration/mainnet/debug_traceBlockByNumber/test_44.json
+++ b/integration/mainnet/debug_traceBlockByNumber/test_44.json
@@ -23,7 +23,21 @@
             "reference": ""
         },
         "metadata": {
-            "latest": true
+            "latest": true,
+            "ignoreFields": [
+                "result[*].result.error",
+                "result[*].result.calls[*].error",
+                "result[*].result.calls[*].calls[*].error",
+                "result[*].result.calls[*].calls[*].calls[*].error",
+                "result[*].result.calls[*].calls[*].calls[*].calls[*].error",
+                "result[*].result.calls[*].calls[*].calls[*].calls[*].calls[*].error",
+                "result[*].result.calls[*].calls[*].calls[*].calls[*].calls[*].calls[*].error",
+                "result[*].result.calls[*].calls[*].calls[*].calls[*].calls[*].calls[*].calls[*].error",
+                "result[*].result.calls[*].calls[*].calls[*].calls[*].calls[*].calls[*].calls[*].calls[*].error",
+                "result[*].result.calls[*].calls[*].calls[*].calls[*].calls[*].calls[*].calls[*].calls[*].calls[*].error",
+                "result[*].result.calls[*].calls[*].calls[*].calls[*].calls[*].calls[*].calls[*].calls[*].calls[*].calls[*].error",
+                "result[*].result.calls[*].calls[*].calls[*].calls[*].calls[*].calls[*].calls[*].calls[*].calls[*].calls[*].calls[*].error"
+            ]
         }
     }
 ]

--- a/integration/mainnet/debug_traceBlockByNumber/test_47.json
+++ b/integration/mainnet/debug_traceBlockByNumber/test_47.json
@@ -20,7 +20,10 @@
             "reference": ""
         },
         "metadata": {
-            "latest": true
+            "latest": true,
+            "ignoreFields": [
+                "result[*].result[*].error"
+            ]
         }
     }
 ]


### PR DESCRIPTION
`debug_traceBlockByNumber` test_44 (callTracer) and test_47 (flatCallTracer) trace the latest block and compare the `error` field verbatim, so they fail whenever that block happens to contain an out-of-gas internal call and the two nodes format the error differently.

Ignore that field, as test_24 already does for the struct logger. callTracer needs one pattern per `calls` nesting level because `ignoreFields` has no recursive wildcard.
